### PR TITLE
Apply scout lens to all recon units

### DIFF
--- a/UI/Lenses/ModLens_Scout.lua
+++ b/UI/Lenses/ModLens_Scout.lua
@@ -58,14 +58,15 @@ end
 local function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, hexJ:number, hexK:number, bSelected:boolean, bEditable:boolean )
     if playerID == Game.GetLocalPlayer() then
         local unitType = GetUnitType(playerID, unitID);
+        local promotionClass = GameInfo.Units[unitType].PromotionClass;
         if unitType then
             if bSelected then
-                if unitType == "UNIT_SCOUT" and AUTO_APPLY_SCOUT_LENS then
+                if promotionClass == "PROMOTION_CLASS_RECON" and AUTO_APPLY_SCOUT_LENS then
                     ShowScoutLens();
                 end
             -- Deselection
             else
-                if unitType == "UNIT_SCOUT" and AUTO_APPLY_SCOUT_LENS then
+                if promotionClass == "PROMOTION_CLASS_RECON" and AUTO_APPLY_SCOUT_LENS then
                     ClearScoutLens();
                 end
             end


### PR DESCRIPTION
Fix we've push in CQUI to apply scout lens to all recon units, currently it only appears for the `UNIT_SCOUT` type, leaving behind all the other era units (recon, spec-ops) and the civ-specific ones (Cree, Scotland, ...).