### PR TITLE
Toggle unit lenses via single hotkey

### DIFF
--- a/Base/Assets/UI/WorldView/SelectedUnit.lua
+++ b/Base/Assets/UI/WorldView/SelectedUnit.lua
@@ -1,0 +1,471 @@
+-- ===========================================================================
+--	Handles selected unit actions with the game engine
+-- ===========================================================================
+
+
+-- ===========================================================================
+--	VARIABLES
+-- ===========================================================================
+local AUTO_APPLY_SETLER_LENS = true
+local AUTO_APPLY_RELIGION_LENS = true
+
+local m_MovementRange : number = UILens.CreateLensLayerHash("Movement_Range");
+local m_MovementZoneOfControl : number = UILens.CreateLensLayerHash("Movement_Zone_Of_Control");
+local m_HexColoringWaterAvail : number = UILens.CreateLensLayerHash("Hex_Coloring_Water_Availablity");
+local m_HexColoringReligion : number = UILens.CreateLensLayerHash("Hex_Coloring_Religion");
+local m_Selection : number = UILens.CreateLensLayerHash("Selection");
+
+-- ===========================================================================
+--	GLOBALS
+-- ===========================================================================
+
+m_HexColoringGreatPeople = UILens.CreateLensLayerHash("Hex_Coloring_Great_People");
+
+-- ===========================================================================
+--	MEMBERS
+-- ===========================================================================
+
+-- ===========================================================================
+function RealizeMoveRadius( kUnit:table )
+	
+	UILens.ClearLayerHexes( m_MovementRange );
+	UILens.ClearLayerHexes( m_MovementZoneOfControl );
+
+	if kUnit ~= nil and ( not GameInfo.Units[kUnit:GetUnitType()].IgnoreMoves ) and ( not UI.IsGameCoreBusy() ) then
+		
+		if not ( kUnit:GetMovesRemaining() > 0 )then
+			return;
+		end
+		
+		local eLocalPlayer	:number = Game.GetLocalPlayer();
+		local kUnitInfo		:table = GameInfo.Units[kUnit:GetUnitType()];
+
+		if kUnitInfo ~= nil and (kUnitInfo.Spy or kUnitInfo.MakeTradeRoute) then
+			-- Spies and Traders don't move like normal units so these lens layers can be ignored
+			return;
+			
+		else
+			local kAttackPlots			:table = UnitManager.GetReachableTargets( kUnit );
+			local kMovePlots			:table = nil;
+			local kZOCPlots				:table = nil;
+			local kAttackIndicators		:table = {};
+			
+			if not kUnit:HasMovedIntoZOC() then
+				kMovePlots	 = UnitManager.GetReachableMovement( kUnit );
+				kZOCPlots	 = UnitManager.GetReachableZonesOfControl( kUnit, true );	-- Only plots visible to the unit.
+				if kZOCPlots == nil then kZOCPlots = {} end
+			else
+				kMovePlots = {};
+				kZOCPlots = {};
+				table.insert( kMovePlots, Map.GetPlot( kUnit:GetX(), kUnit:GetY() ):GetIndex() );
+			end
+						
+			local isShowingTarget :boolean = kUnit:GetAttacksRemaining() > 0;
+
+			-- Extract attack indicator locations and extensions to movement range
+			if isShowingTarget and kAttackPlots ~= nil and table.count( kAttackPlots ) > 0 then
+				if kMovePlots == nil then kMovePlots = {} end
+				for _, plot in ipairs( kAttackPlots ) do
+					table.insert( kAttackIndicators, { "AttackRange_Target", plot } );
+					table.insert( kMovePlots, plot );
+				end
+			end
+
+			-- Extract attack indicator locations for ranged attacks
+			local pResults = UnitManager.GetOperationTargets(kUnit, UnitOperationTypes.RANGE_ATTACK );
+			local pAllPlots = pResults[UnitOperationResults.PLOTS];
+			if pAllPlots ~= nil then
+				for i, modifier in ipairs( pResults[UnitOperationResults.MODIFIERS] ) do
+					if modifier == UnitOperationResults.MODIFIER_IS_TARGET then
+						-- Dedupe hexes
+						local kPlotId :number = pAllPlots[i];
+						local isUnique : boolean = true;
+						for k, v in ipairs( kAttackIndicators ) do
+							if v[2] == kPlotId then
+								isUnique = false;
+								break;
+							end
+						end
+						if isUnique then
+							table.insert( kAttackIndicators, { "AttackRange_Target", kPlotId } );
+						end
+					end
+				end
+			end
+
+			-- Lay down ZOC and attack indicators
+			if table.count( kZOCPlots ) > 0 or table.count( kAttackIndicators ) > 0 then
+				UILens.SetLayerHexesArea( m_MovementZoneOfControl, eLocalPlayer, kZOCPlots, kAttackIndicators );
+			end
+
+			-- Lay down movement border around movable and attack-movable hexes
+			if kMovePlots ~= nil and table.count( kMovePlots ) > 0 then
+				UILens.SetLayerHexesArea( m_MovementRange, eLocalPlayer, kMovePlots );
+			end
+		end
+	end
+end
+
+-- ===========================================================================
+function RealizeGreatPersonLens( kUnit:table )
+	UILens.ClearLayerHexes(m_HexColoringGreatPeople);
+	if UILens.IsLayerOn( m_HexColoringGreatPeople ) then
+		UILens.ToggleLayerOff(m_HexColoringGreatPeople);
+	end
+	if kUnit ~= nil and ( not UI.IsGameCoreBusy() ) then
+		local playerID:number = kUnit:GetOwner();
+		if playerID == Game.GetLocalPlayer() then
+			local kUnitArchaeology:table = kUnit:GetArchaeology();
+			local kUnitGreatPerson:table = kUnit:GetGreatPerson();
+			if kUnitGreatPerson ~= nil and kUnitGreatPerson:IsGreatPerson() then
+				local greatPersonInfo:table = GameInfo.GreatPersonIndividuals[kUnitGreatPerson:GetIndividual()];
+				-- Highlight an area around the Great Person (if they have an area of effect trait)
+				local areaHighlightPlots:table = {};
+				if (greatPersonInfo ~= nil and greatPersonInfo.AreaHighlightRadius ~= nil) then
+					areaHighlightPlots = kUnitGreatPerson:GetAreaHighlightPlots();
+				end
+				-- Highlight the plots the Great Person could use its action on
+				local activationPlots:table = {};
+				if (greatPersonInfo ~= nil and greatPersonInfo.ActionEffectTileHighlighting ~= nil and greatPersonInfo.ActionEffectTileHighlighting) then
+					local rawActivationPlots:table = kUnitGreatPerson:GetActivationHighlightPlots();
+					for _,plotIndex:number in ipairs(rawActivationPlots) do
+						table.insert(activationPlots, {"Great_People", plotIndex});
+					end
+				end
+				UILens.SetLayerHexesArea(m_HexColoringGreatPeople, playerID, areaHighlightPlots, activationPlots);
+				UILens.ToggleLayerOn(m_HexColoringGreatPeople);
+			elseif( kUnitArchaeology ~= nil and GameInfo.Units[kUnit:GetUnitType()].ExtractsArtifacts == true) then 
+				-- Highlight plots that can activated by Archaeologists
+				local activationPlots:table = {};
+				local rawActivationPlots:table = kUnitArchaeology:GetActivationHighlightPlots();
+				for _,plotIndex:number in ipairs(rawActivationPlots) do
+					table.insert(activationPlots, {"Great_People", plotIndex});
+				end
+					
+				UILens.SetLayerHexesArea(m_HexColoringGreatPeople, playerID, {}, activationPlots);
+				UILens.ToggleLayerOn(m_HexColoringGreatPeople);
+			elseif GameInfo.Units[kUnit:GetUnitType()].ParkCharges > 0 then -- Highlight plots that can activated by Naturalists
+				local parkPlots:table = {};
+				local rawParkPlots:table = Game.GetNationalParks():GetPossibleParkTiles(playerID);
+				for _,plotIndex:number in ipairs(rawParkPlots) do
+					table.insert(parkPlots, {"Great_People", plotIndex});
+				end
+				UILens.SetLayerHexesArea(m_HexColoringGreatPeople, playerID, {}, parkPlots);
+				UILens.ToggleLayerOn(m_HexColoringGreatPeople);
+			end
+		end
+	end
+end
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnUnitVisibilityChanged( playerID: number, unitID : number, eVisibility : number)
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, hexJ:number, hexK:number, isSelected:boolean, isEditable:boolean )
+	if playerID ~= Game.GetLocalPlayer() then
+		return;
+	end
+
+	-- Mode(s) to skip selecting a unit
+	local eMode:number = UI.GetInterfaceMode();
+	if eMode == InterfaceModeTypes.CINEMATIC then return; end	-- (Still) in Cinematic mode; one may have just queued up after the other.
+
+
+	local kUnit		:table = nil;
+	local pPlayer	:table = Players[playerID];
+	if pPlayer ~= nil then
+		kUnit = pPlayer:GetUnits():FindID(unitID);
+
+		if isSelected then
+			-- If a selection is occuring and the modal lens interface mode is up, take it down.
+			if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+				UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+			end
+			
+			-- If a selection is occuring and the city attack interface mode is up, take it down.
+			if UI.GetInterfaceMode() == InterfaceModeTypes.CITY_RANGE_ATTACK then
+				UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+			end
+
+			UILens.SetActive("Default");
+
+			local religiousStrength :number = kUnit:GetReligiousStrength();
+			if religiousStrength > 0 and not UILens.IsLensActive("Religion") and AUTO_APPLY_RELIGION_LENS then
+				UILens.SetActive("Religion");
+			elseif GameInfo.Units[kUnit:GetUnitType()].FoundCity and AUTO_APPLY_SETLER_LENS and pPlayer:GetCities():GetCount() > 0 then
+				UILens.ToggleLayerOn(m_HexColoringWaterAvail);			-- Used on the settler lens
+			end
+		else
+			if kUnit ~= nil then
+				local religiousStrength :number = kUnit:GetReligiousStrength();
+				if religiousStrength > 0 and UILens.IsLensActive("Religion") then
+					UILens.SetActive("Default");
+				elseif GameInfo.Units[kUnit:GetUnitType()].FoundCity and UILens.IsLayerOn(m_HexColoringWaterAvail) then
+					UILens.ToggleLayerOff(m_HexColoringWaterAvail);
+				end
+				kUnit = nil; -- Ensure movement radius is turned off.
+			else
+				-- No selected unit, if a missionary just consumed themselves,
+				-- kUnit will be nul but the lens still needs to be turned off.
+				if UILens.IsLensActive("Religion") then
+					UILens.SetActive("Default");
+				end
+			end
+		end
+	end
+
+	RealizeMoveRadius( kUnit );
+	RealizeGreatPersonLens( kUnit );
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function UnitSimPositionChanged( playerID:number, unitID:number, worldX:number, worldY:number, worldZ:number, bVisible:boolean, isComplete:boolean )
+	if playerID ~= Game.GetLocalPlayer() then
+		return
+	end
+	local kUnit:table = nil;
+	if isComplete then
+		local pPlayer:table = Players[ playerID ];
+		if pPlayer ~= nil then
+			-- If the unit that just finished moving is STILL the selected unit,
+			-- then it has more moves to make, update the move radius...
+			kUnit = pPlayer:GetUnits():FindID(unitID);
+			if kUnit == UI.GetHeadSelectedUnit() then
+				RealizeMoveRadius( kUnit );
+				RealizeGreatPersonLens( kUnit );
+			end
+		end
+	end
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnBeginWonderReveal()
+	UILens.ToggleLayerOff(m_Selection);
+	UILens.ClearLayerHexes(m_Selection);
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnEndWonderReveal()
+	UILens.ToggleLayerOn(m_Selection);
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
+	if eNewMode == InterfaceModeTypes.VIEW_MODAL_LENS then
+		UI.DeselectAll();
+	end
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnLensLayerOn( layerNum:number )
+	if layerNum == m_MovementRange then
+		local pUnit:table = UI.GetHeadSelectedUnit();
+		if pUnit ~= nil then
+			RealizeMoveRadius( pUnit );
+		end
+	end
+end
+
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnCombatVisBegin()
+	UILens.ClearLayerHexes( m_MovementRange );
+	UILens.ClearLayerHexes( m_MovementZoneOfControl  );
+	UILens.ClearLayerHexes( m_Selection );
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnCombatVisEnd(aCombatVisData : table)
+
+	-- Only do this if the local player was involved
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+
+	local isInvolvesLocalPlayer = false;
+
+	for _, i in ipairs(aCombatVisData) do
+		if i.playerID == localPlayerID then
+			isInvolvesLocalPlayer = true;
+		end
+	end
+
+	if isInvolvesLocalPlayer then
+
+		local pUnit :table = UI.GetHeadSelectedUnit();
+
+		-- Explicitly deselect the unit if they have no more moves, this allows
+		-- UI pieces stop showing the previous unit's info.
+		if pUnit ~= nil and aCombatVisData[CombatVisType.ATTACKER].componentID == pUnit:GetID() and pUnit:GetMovesRemaining() == 0 then
+			UI.DeselectUnit(pUnit);
+			-- Start the timer for the UI systems auto unit cycling code, which will handle selecting the next unit
+			-- This is better than calling the selection advance directly because queued events may pending that want to control the camera.
+			UI.SetCycleAdvanceTimer();
+		end
+	end
+end
+
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnLocalPlayerTurnBegin()
+	local idLocalPlayer	:number = Game.GetLocalPlayer();
+	local pPlayer		:table = Players[ idLocalPlayer ];
+	
+	if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+		UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+	end
+	UILens.SetActive("Default");
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnPlayerTurnActivated( ePlayer:number, isFirstTime:boolean )
+	if ePlayer == Game.GetLocalPlayer() then
+		local kUnit = UI.GetHeadSelectedUnit();
+		if (kUnit ~= nil) then
+			RealizeMoveRadius( kUnit );
+		end
+	end
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnUnitPromotionChanged(playerID : number, unitID : number )
+	local idLocalPlayer	:number = Game.GetLocalPlayer();
+	if idLocalPlayer > -1 and playerID == idLocalPlayer then
+		local kUnit = UI.GetHeadSelectedUnit();
+		if (kUnit ~= nil) then
+			RealizeMoveRadius( kUnit );
+		end
+	end
+end
+
+-- ===========================================================================
+--	Game Engine Event
+-- ===========================================================================
+function OnUnitTeleported(playerID: number, unitID : number, x : number, y : number)
+	local idLocalPlayer	:number = Game.GetLocalPlayer();
+	if idLocalPlayer > -1 and playerID == idLocalPlayer then
+		local kUnit = UI.GetHeadSelectedUnit();
+		if (kUnit ~= nil) then
+			RealizeMoveRadius( kUnit );
+			RealizeGreatPersonLens( kUnit );
+		end
+	end
+end
+
+-- ===========================================================================
+--	Engine EVENT
+--	Local player changed; likely a hotseat game
+-- ===========================================================================
+function OnLocalPlayerChanged( eLocalPlayer:number , ePrevLocalPlayer:number )
+	if eLocalPlayer == -1 then
+		return;
+	end
+	UI.DeselectAllUnits();
+	UI.DeselectAllCities();
+
+	-- Equivalent to original code, not sure if actually needed
+	if UILens.IsLensActive("Religion") then
+		UILens.ClearLayerHexes( m_HexColoringReligion );
+	end
+	
+	if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+		UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+	end
+	UILens.SetActive("Default");
+
+	if(UILens.IsLayerOn(m_HexColoringGreatPeople)) then
+		UILens.ClearLayerHexes( m_HexColoringGreatPeople );
+		UILens.ToggleLayerOff( m_HexColoringGreatPeople );
+	end
+
+	if(UILens.IsLayerOn(m_HexColoringWaterAvail)) then
+		UILens.ClearLayerHexes( m_HexColoringWaterAvail );
+		UILens.ToggleLayerOff( m_HexColoringWaterAvail );
+	end
+
+	if(UILens.IsLayerOn(m_MovementZoneOfControl)) then
+		UILens.ClearLayerHexes( m_MovementZoneOfControl );
+		UILens.ToggleLayerOff( m_MovementZoneOfControl );
+	end
+
+	if(UILens.IsLayerOn(m_MovementRange)) then
+		UILens.ClearLayerHexes( m_MovementRange );
+		UILens.ToggleLayerOff( m_MovementRange );
+	end
+end
+-- ===========================================================================
+--	LUA Event
+--	Do not show "water" available lens when settler is selected.
+-- ===========================================================================
+function OnTutorialUIRoot_DisableSettleHintLens()
+	AUTO_APPLY_SETLER_LENS = false;
+end
+
+-- ===========================================================================
+--	UI Event
+-- ===========================================================================
+function OnContextInitialize(bHotload : boolean)
+	if bHotload then
+	end
+end
+
+-- ===========================================================================
+--	Handle the UI shutting down.
+function OnShutdown()
+	Events.LocalPlayerTurnBegin.Remove( OnLocalPlayerTurnBegin );
+	Events.UnitSelectionChanged.Remove( OnUnitSelectionChanged );
+	Events.UnitSimPositionChanged.Remove( UnitSimPositionChanged );
+	Events.UnitVisibilityChanged.Remove( OnUnitVisibilityChanged );
+end
+
+-- ===========================================================================
+function Initialize()
+
+	UI.SetSelectedUnitUIArt("MovementGood_Select");
+
+	ContextPtr:SetInitHandler( OnContextInitialize );
+	ContextPtr:SetShutdown( OnShutdown );
+
+	Events.BeginWonderReveal.Add( OnBeginWonderReveal );
+	Events.CombatVisBegin.Add( OnCombatVisBegin );
+	Events.CombatVisEnd.Add( OnCombatVisEnd );
+	Events.EndWonderReveal.Add( OnEndWonderReveal );
+	Events.InterfaceModeChanged.Add( OnInterfaceModeChanged );
+	Events.LensLayerOn.Add( OnLensLayerOn );
+	Events.LocalPlayerTurnBegin.Add( OnLocalPlayerTurnBegin );
+	Events.PlayerTurnActivated.Add( OnPlayerTurnActivated );
+	Events.UnitTeleported.Add( OnUnitTeleported );
+	Events.UnitPromoted.Add( OnUnitPromotionChanged );
+	Events.UnitSelectionChanged.Add( OnUnitSelectionChanged );
+	Events.UnitSimPositionChanged.Add( UnitSimPositionChanged );
+	Events.UnitVisibilityChanged.Add( OnUnitVisibilityChanged );
+	Events.LocalPlayerChanged.Add(OnLocalPlayerChanged);
+
+	LuaEvents.TutorialUIRoot_DisableSettleHintLens.Add( OnTutorialUIRoot_DisableSettleHintLens );
+end
+Initialize();

--- a/Lenses/ModLens_Archaeologist.lua
+++ b/Lenses/ModLens_Archaeologist.lua
@@ -64,12 +64,12 @@ local function OnGetColorPlotTable()
 end
 
 -- Called when an archaeologist is selected
-local function ShowArchaeologistLens()
+function ShowArchaeologistLens()
     LuaEvents.MinimapPanel_SetActiveModLens(LENS_NAME)
     UILens.ToggleLayerOn(ML_LENS_LAYER)
 end
 
-local function ClearArchaeologistLens()
+function ClearArchaeologistLens()
     if UILens.IsLayerOn(ML_LENS_LAYER) then
         UILens.ToggleLayerOff(ML_LENS_LAYER)
     end
@@ -86,7 +86,7 @@ local function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:numb
                 end
             -- Deselection
             else
-                if unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHEOLOGIST_LENS then
+                if unitType == "UNIT_ARCHAEOLOGIST" then
                     ClearArchaeologistLens()
                 end
             end
@@ -99,7 +99,7 @@ local function OnUnitRemovedFromMap( playerID: number, unitID : number )
     local lens = {}
     LuaEvents.MinimapPanel_GetActiveModLens(lens)
     if playerID == localPlayer then
-        if lens[1] == LENS_NAME and AUTO_APPLY_ARCHEOLOGIST_LENS then
+        if lens[1] == LENS_NAME then
             ClearArchaeologistLens()
         end
     end
@@ -110,7 +110,7 @@ function OnUnitCaptured( currentUnitOwner, unit, owningPlayer, capturingPlayer )
     local localPlayer = Game.GetLocalPlayer()
     if owningPlayer == localPlayer then
         local unitType = GetUnitTypeFromIDs(owningPlayer, unitID)
-        if unitType and unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHEOLOGIST_LENS then
+        if unitType and unitType == "UNIT_ARCHAEOLOGIST" then
             ClearArchaeologistLens()
         end
     end

--- a/Lenses/ModLens_Builder.lua
+++ b/Lenses/ModLens_Builder.lua
@@ -88,13 +88,14 @@ local function OnGetColorPlotTable()
     return colorPlot
 end
 
+
 -- Called when a builder is selected
-local function ShowBuilderLens()
+function ShowBuilderLens()
     LuaEvents.MinimapPanel_SetActiveModLens(LENS_NAME)
     UILens.ToggleLayerOn(ML_LENS_LAYER)
 end
 
-local function ClearBuilderLens()
+function ClearBuilderLens()
     -- print("Clearing builder lens")
     if UILens.IsLayerOn(ML_LENS_LAYER) then
         UILens.ToggleLayerOff(ML_LENS_LAYER);
@@ -112,7 +113,7 @@ local function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:numb
                 end
             -- Deselection
             else
-                if unitType == "UNIT_BUILDER" and AUTO_APPLY_BUILDER_LENS then
+                if unitType == "UNIT_BUILDER" then
                     ClearBuilderLens();
                 end
             end
@@ -124,7 +125,7 @@ local function OnUnitChargesChanged( playerID: number, unitID : number, newCharg
     local localPlayer = Game.GetLocalPlayer()
     if playerID == localPlayer then
         local unitType = GetUnitTypeFromIDs(playerID, unitID)
-        if unitType and unitType == "UNIT_BUILDER" and AUTO_APPLY_BUILDER_LENS then
+        if unitType and unitType == "UNIT_BUILDER" then
             if newCharges == 0 then
                 ClearBuilderLens();
             end
@@ -137,7 +138,7 @@ local function OnUnitCaptured( currentUnitOwner, unit, owningPlayer, capturingPl
     local localPlayer = Game.GetLocalPlayer()
     if owningPlayer == localPlayer then
         local unitType = GetUnitTypeFromIDs(owningPlayer, unitID)
-        if unitType and unitType == "UNIT_BUILDER" and AUTO_APPLY_BUILDER_LENS then
+        if unitType and unitType == "UNIT_BUILDER" then
             ClearBuilderLens();
         end
     end
@@ -148,7 +149,7 @@ local function OnUnitRemovedFromMap( playerID: number, unitID : number )
     local lens = {}
     LuaEvents.MinimapPanel_GetActiveModLens(lens)
     if playerID == localPlayer then
-        if lens[1] == LENS_NAME and AUTO_APPLY_BUILDER_LENS then
+        if lens[1] == LENS_NAME then
             ClearBuilderLens();
         end
     end

--- a/Lenses/ModLens_Scout.lua
+++ b/Lenses/ModLens_Scout.lua
@@ -43,12 +43,12 @@ local function OnGetColorPlotTable()
 end
 
 -- Called when a scout is selected
-local function ShowScoutLens()
+function ShowScoutLens()
     LuaEvents.MinimapPanel_SetActiveModLens(LENS_NAME)
     UILens.ToggleLayerOn(ML_LENS_LAYER)
 end
 
-local function ClearScoutLens()
+function ClearScoutLens()
     if UILens.IsLayerOn(ML_LENS_LAYER) then
         UILens.ToggleLayerOff(ML_LENS_LAYER)
     end
@@ -56,8 +56,10 @@ local function ClearScoutLens()
 end
 
 local function RefreshScoutLens()
-    ClearScoutLens()
-    ShowScoutLens()
+    if UILens.IsLayerOn(ML_LENS_LAYER) then
+        ClearScoutLens()
+        ShowScoutLens()
+    end
 end
 
 local function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, hexJ:number, hexK:number, bSelected:boolean, bEditable:boolean )
@@ -72,7 +74,7 @@ local function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:numb
                     end
                 -- Deselection
                 else
-                    if promotionClass == "PROMOTION_CLASS_RECON" and AUTO_APPLY_SCOUT_LENS then
+                    if promotionClass == "PROMOTION_CLASS_RECON" then
                         ClearScoutLens()
                     end
                 end
@@ -86,7 +88,7 @@ local function OnUnitRemovedFromMap( playerID: number, unitID : number )
     local lens = {}
     if playerID == localPlayer then
         LuaEvents.MinimapPanel_GetActiveModLens(lens)
-        if lens[1] == LENS_NAME and AUTO_APPLY_SCOUT_LENS then
+        if lens[1] == LENS_NAME then
             ClearScoutLens()
         end
     end
@@ -97,7 +99,7 @@ local function OnUnitMoveComplete( playerID:number, unitID:number )
         local unitType = GetUnitTypeFromIDs(playerID, unitID)
         local promotionClass = GameInfo.Units[unitType].PromotionClass
         if unitType then
-            if promotionClass == "PROMOTION_CLASS_RECON" and AUTO_APPLY_SCOUT_LENS then
+            if promotionClass == "PROMOTION_CLASS_RECON" then
                 RefreshScoutLens()
             end
         end
@@ -108,7 +110,7 @@ local function OnGoodyHutReward( playerID:number )
     if playerID == Game.GetLocalPlayer() then
         local lens = {}
         LuaEvents.MinimapPanel_GetActiveModLens(lens)
-        if lens[1] == LENS_NAME and AUTO_APPLY_SCOUT_LENS then
+        if lens[1] == LENS_NAME then
             RefreshScoutLens()
         end
     end

--- a/Lenses/ModLens_ToggleUnitLense.lua
+++ b/Lenses/ModLens_ToggleUnitLense.lua
@@ -1,0 +1,88 @@
+-- ===========================================================================
+--    Toggle Unit Lense
+-- ===========================================================================
+
+include("ModLens_Archaeologist")
+include("ModLens_Builder")
+include("ModLens_Scout")
+
+local m_SettlerLensLayerHash : number = UILens.CreateLensLayerHash("Hex_Coloring_Water_Availablity");
+local m_ModLensLayerHash : number = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level");
+
+function OnToggleUnitLense()
+    local pUnit :table = UI.GetHeadSelectedUnit();
+    if( pUnit == nil ) then
+        return;
+    end
+  
+    local bPlaySound :boolean = true;
+    local religiousStrength :number = pUnit:GetReligiousStrength();
+    local unitType = GameInfo.Units[pUnit:GetUnitType()].UnitType;
+    local unitPromotionClass = GameInfo.Units[pUnit:GetUnitType()].PromotionClass;
+    
+    if GameInfo.Units[pUnit:GetUnitType()].FoundCity then
+        if UILens.IsLayerOn(m_SettlerLensLayerHash) then
+            UILens.ToggleLayerOff(m_SettlerLensLayerHash);
+        else
+            UILens.ToggleLayerOn(m_SettlerLensLayerHash);
+        end
+    elseif religiousStrength > 0 then
+        if UILens.IsLensActive("Religion") then
+            UILens.SetActive("Default");
+        else
+            UILens.SetActive("Religion");
+        end
+    elseif unitType == "UNIT_ARCHAEOLOGIST" then
+        if UILens.IsLayerOn(m_ModLensLayerHash) then
+            ClearArchaeologistLens();
+        else
+            ShowArchaeologistLens();
+        end
+    elseif unitType == "UNIT_BUILDER" then
+        if UILens.IsLayerOn(m_ModLensLayerHash) then
+            ClearBuilderLens();
+        else
+            ShowBuilderLens();
+        end
+    elseif unitPromotionClass == "PROMOTION_CLASS_RECON" then
+        if UILens.IsLayerOn(m_ModLensLayerHash) then
+            ClearScoutLens();
+        else
+            ShowScoutLens();
+        end
+    else
+        bPlaySound = false
+    end
+  
+    if bPlaySound then
+        UI.PlaySound("Play_UI_Click");    
+    end
+end
+
+function OnIngameAction(actionId)
+    if Game.GetLocalPlayer() == -1 then
+        return;
+    end
+    if actionId == Input.GetActionId("ModLens_ToggleUnitLense") then
+        OnToggleUnitLense();
+    end
+end
+
+
+-- ===========================================================================
+-- INITIALIZATION
+-- ===========================================================================
+function OnInit(isReload:boolean)
+
+end
+
+function OnShutdown()
+    Events.InputActionTriggered.Remove( OnIngameAction );
+end
+
+function Initialize()
+    ContextPtr:SetInitHandler( OnInit );
+    ContextPtr:SetShutdown( OnShutdown );
+    Events.InputActionTriggered.Add( OnIngameAction );
+end
+Initialize();

--- a/Lenses/ModLens_ToggleUnitLense.xml
+++ b/Lenses/ModLens_ToggleUnitLense.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameInfo>
+	<InputActions>	
+		<Row ActionId="ModLens_ToggleUnitLense" Name="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Description="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" CategoryId="LENSES" ContextId="World" />
+	</InputActions>
+	
+	<InputActionDefaultGestures>
+		<Row ActionId="ModLens_ToggleUnitLense" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_TAB"/>
+	</InputActionDefaultGestures>
+</GameInfo>

--- a/MoreLenses.modinfo
+++ b/MoreLenses.modinfo
@@ -21,8 +21,40 @@
       <GameCoreInUse>Expansion2</GameCoreInUse>
     </Criteria>
   </ActionCriteria>
-
+  
+  <FrontEndActions>
+    <UpdateDatabase id="MORELENSES_TOGGLE_UNIT_LENSE">
+      <File>Lenses/ModLens_ToggleUnitLense.xml</File>
+    </UpdateDatabase>
+    <UpdateText id="MORELENSES_TEXT">
+      <Items>
+        <File>Text/MoreLenses_Text.xml</File>
+        <File>Text/MoreLenses_Text_de.xml</File>
+        <File>Text/MoreLenses_Text_fr.xml</File>
+        <File>Text/MoreLenses_Text_it.xml</File>
+        <File>Text/MoreLenses_Text_ko.xml</File>
+        <File>Text/MoreLenses_Text_pl.xml</File>
+        <File>Text/MoreLenses_Text_ru.xml</File>
+        <File>Text/MoreLenses_Text_zh.xml</File>
+        <File>Text/MoreLenses_Text_es.xml</File>
+      </Items>
+    </UpdateText>
+   </FrontEndActions>
+   
   <InGameActions>
+     <UpdateText id="MORELENSES_TEXT">
+      <Items>
+        <File>Text/MoreLenses_Text.xml</File>
+        <File>Text/MoreLenses_Text_de.xml</File>
+        <File>Text/MoreLenses_Text_fr.xml</File>
+        <File>Text/MoreLenses_Text_it.xml</File>
+        <File>Text/MoreLenses_Text_ko.xml</File>
+        <File>Text/MoreLenses_Text_pl.xml</File>
+        <File>Text/MoreLenses_Text_ru.xml</File>
+        <File>Text/MoreLenses_Text_zh.xml</File>
+        <File>Text/MoreLenses_Text_es.xml</File>
+      </Items>
+     </UpdateText>
      <AddUserInterfaces id="MORELENSES_LENSES_WPANEL">
       <Properties>
         <Context>InGame</Context>
@@ -30,8 +62,9 @@
       </Properties>
       <Items>
         <File>Lenses/ModLens_CityOverlap.xml</File>
-        <!-- ModLens_CityOverlap.lua implied -->
+        <!-- ModLens_CityOverlap.lua and ModLens_ToggleUnitLense.lua implied -->
         <File>Lenses/ModLens_Resource.xml</File>
+        <File>Lenses/ModLens_ToggleUnitLense.xml</File>
       </Items>
     </AddUserInterfaces>
 
@@ -70,6 +103,7 @@
         <File>Base/Assets/UI/MinimapPanel.xml</File>
         <File>Base/Assets/UI/Panels/ModalLensPanel.lua</File>
         <File>Base/Assets/UI/Panels/ModalLensPanel.xml</File>
+        <File>Base/Assets/UI/WorldView/SelectedUnit.lua</File>
       </Items>
     </ImportFiles>
 
@@ -96,20 +130,6 @@
         <File>MoreLenses_Colors.sql</File>
       </Items>
     </UpdateDatabase>
-
-    <LocalizedText id="MORELENSES_TEXT">
-      <Items>
-        <File>Text/MoreLenses_Text.xml</File>
-        <File>Text/MoreLenses_Text_de.xml</File>
-        <File>Text/MoreLenses_Text_fr.xml</File>
-        <File>Text/MoreLenses_Text_it.xml</File>
-        <File>Text/MoreLenses_Text_ko.xml</File>
-        <File>Text/MoreLenses_Text_pl.xml</File>
-        <File>Text/MoreLenses_Text_ru.xml</File>
-        <File>Text/MoreLenses_Text_zh.xml</File>
-        <File>Text/MoreLenses_Text_es.xml</File>
-      </Items>
-    </LocalizedText>
   </InGameActions>
 
   <Files>
@@ -126,6 +146,7 @@
     <File>Base/Assets/UI/MinimapPanel.xml</File>
     <File>Base/Assets/UI/Panels/ModalLensPanel.lua</File>
     <File>Base/Assets/UI/Panels/ModalLensPanel.xml</File>
+    <File>Base/Assets/UI/WorldView/SelectedUnit.lua</File>
     <File>MoreLenses_Colors.sql</File>
     <File>Lenses/LensSupport.lua</File>
     <File>Lenses/ModLens_Builder.lua</File>
@@ -135,6 +156,8 @@
     <File>Lenses/ModLens_Barbarian.lua</File>
     <File>Lenses/ModLens_Naturalist.lua</File>
     <File>Lenses/ModLens_Wonder.lua</File>
+    <File>Lenses/ModLens_ToggleUnitLense.xml</File>
+    <File>Lenses/ModLens_ToggleUnitLense.lua</File>
     <File>Lenses/ModLens_CityOverlap.xml</File>
     <File>Lenses/ModLens_CityOverlap.lua</File>
     <File>Lenses/ModLens_Resource.xml</File>

--- a/Text/MoreLenses_Text.xml
+++ b/Text/MoreLenses_Text.xml
@@ -3,6 +3,11 @@
   <BaseGameText>
     <!-- ENGLISH -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Row Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL">
+      <Text>Toggle Unit Lense</Text>
+    </Row>
+
     <!-- Builder Lens -->
     <Row Tag="LOC_HUD_BUILDER_LENS">
       <Text>Builder</Text>

--- a/Text/MoreLenses_Text_de.xml
+++ b/Text/MoreLenses_Text_de.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- GERMAN -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="de_DE">
+      <Text>Einheitenlinse umschalten</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="de_DE">
       <Text>Handwerker</Text>

--- a/Text/MoreLenses_Text_es.xml
+++ b/Text/MoreLenses_Text_es.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- SPANISH -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="es_ES">
+      <Text>Lente de unidad de palanca</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="es_ES">
       <Text>Constructor</Text>

--- a/Text/MoreLenses_Text_fr.xml
+++ b/Text/MoreLenses_Text_fr.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- FRENCH -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="fr_FR">
+      <Text>Bascule unité lentille</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="fr_FR">
       <Text>Bâtisseur</Text>

--- a/Text/MoreLenses_Text_it.xml
+++ b/Text/MoreLenses_Text_it.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- ITALIAN -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="it_IT">
+      <Text>Cambia lente unità</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="it_IT">
       <Text>Costruttore</Text>

--- a/Text/MoreLenses_Text_ko.xml
+++ b/Text/MoreLenses_Text_ko.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- KOREAN -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="ko_KR">
+      <Text>단위 렌즈를 토글하다</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="ko_KR">
       <Text>건설자</Text>

--- a/Text/MoreLenses_Text_pl.xml
+++ b/Text/MoreLenses_Text_pl.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- POLISH -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="pl_PL">
+      <Text>Przełącz soczewkę jednostki</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="pl_PL">
       <Text>Budowniczowie</Text>

--- a/Text/MoreLenses_Text_ru.xml
+++ b/Text/MoreLenses_Text_ru.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- RUSSIAN -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="ru_RU">
+      <Text>линза переключателя</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="ru_RU">
       <Text>Строитель</Text>

--- a/Text/MoreLenses_Text_zh.xml
+++ b/Text/MoreLenses_Text_zh.xml
@@ -3,6 +3,11 @@
   <LocalizedText>
     <!-- SIMPLIFY-CHINESE -->
 
+    <!-- Toggle Unit Lense Hotkey -->
+    <Replace Tag="LOC_OPTIONS_HOTKEY_LENSES_ML_TUL" Language="zh_Hans_CN">
+      <Text>切换单元镜头</Text>
+    </Replace>
+
     <!-- Builder Lens -->
     <Replace Tag="LOC_HUD_BUILDER_LENS" Language="zh_Hans_CN">
       <Text>建造者</Text>


### PR DESCRIPTION
Adds a hotkey `Toggle Unit Lense` to Game Options -> Key Bindings.
This hotkey allows to toggle unit specific lenses (settler, builder, scout, archaeologist and all religious units).