### PR TITLE
Custom Color for Lenses (from CQUI)

### DIFF
--- a/Base/Assets/UI/Panels/modallenspanel.lua
+++ b/Base/Assets/UI/Panels/modallenspanel.lua
@@ -347,6 +347,37 @@ function AddLensEntry(lensKey:string, lensEntry:table, refreshPanel)
 end
 
 -- ===========================================================================
+function RefreshLensKey(lensKey:string)
+    ResetKeyStackIM();
+    ShowModLensKey(lensKey);
+end
+
+-- ===========================================================================
+function ML_SettingsPanelClosed()
+    -- Get the active lens and refresh it, updating any color changes made
+    local activeModLens = {};
+    LuaEvents.MinimapPanel_GetActiveModLens(activeModLens);
+    if (activeModLens[1] ~= nil and activeModLens[1] ~= "NONE") then
+        if (UILens.IsLensActive("Appeal")) then
+            -- Lens is enabled via the Lenses list
+            RefreshLensKey(activeModLens[1]);
+            -- Turn off and Turn on the Appeal Lens to refresh the colors
+            UILens.SetActive("Default");
+            LuaEvents.MinimapPanel_SetActiveModLens(activeModLens[1]);
+            -- Appeal is used for all of the Modded Lenses
+            UILens.SetActive("Appeal");
+        elseif (UILens.IsLensActive("Default")) then
+            -- Lens is enabled because of a selected unit (e.g. Builder, Scout)
+            local hash = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
+            UILens.ToggleLayerOff(hash);
+            UILens.ToggleLayerOn(hash);
+        else
+            print("!! ERROR: ActiveModLens is "..tostring(activeModLens[1]).."  but UILens is not Appeal or Default!");
+        end
+    end
+end
+
+-- ===========================================================================
 function LateInitialize()
     if (Game.GetLocalPlayer() == -1) then
         return;
@@ -359,6 +390,8 @@ function LateInitialize()
 
     -- Mod Lens Support
     LuaEvents.ModalLensPanel_AddLensEntry.Add( AddLensEntry )
+    -- Support for updating Mod Lens Colors
+    LuaEvents.ML_SettingsPanelClosed.Add( ML_SettingsPanelClosed );
 
     LuaEvents.MinimapPanel_AddContinentColorPair.Add(OnAddContinentColorPair);
 end

--- a/Lenses/Archaeologist/ModLens_Archaeologist.lua
+++ b/Lenses/Archaeologist/ModLens_Archaeologist.lua
@@ -1,8 +1,23 @@
+include("LensSupport")
 local LENS_NAME = "ML_ARCHAEOLOGIST"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
 
+local m_LensSettings = {
+    ["COLOR_ARCHAEOLOGIST_LENS_ARTIFACT"]  = { ConfiguredColor = GetLensColorFromSettings("COLOR_ARCHAEOLOGIST_LENS_ARTIFACT"), KeyLabel = "LOC_HUD_ARCHAEOLOGIST_LENS_ARTIFACT" },
+    ["COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK"] = { ConfiguredColor = GetLensColorFromSettings("COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK"), KeyLabel = "LOC_HUD_ARCHAEOLOGIST_LENS_SHIPWRECK" }
+}
+
 -- Should the archaeologist lens auto apply, when a archaeologist is selected.
-local AUTO_APPLY_ARCHEOLOGIST_LENS:boolean = false
+local AUTO_APPLY_ARCHAEOLOGIST_LENS:boolean = false
+
+local function ML_OnSettingsInitialized()
+    -- NOTE: Setting to control auto-applying the Archaeologist lens is missing?
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
 
 -- ===========================================================================
 -- Archaeologist Lens Support
@@ -34,8 +49,8 @@ local function OnGetColorPlotTable()
     local pPlayer:table = Players[localPlayer]
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local AntiquityColor = UI.GetColorValue("COLOR_ARTIFACT_ARCH_LENS")
-    local ShipwreckColor = UI.GetColorValue("COLOR_SHIPWRECK_ARCH_LENS")
+    local AntiquityColor = m_LensSettings["COLOR_ARCHAEOLOGIST_LENS_ARTIFACT"].ConfiguredColor
+    local ShipwreckColor = m_LensSettings["COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK"].ConfiguredColor
     local IgnoreColor = UI.GetColorValue("COLOR_MORELENSES_GREY")
     local colorPlot = {}
     colorPlot[AntiquityColor] = {}
@@ -81,12 +96,12 @@ local function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:numb
         local unitType = GetUnitTypeFromIDs(playerID, unitID)
         if unitType then
             if bSelected then
-                if unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHEOLOGIST_LENS then
+                if unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHAEOLOGIST_LENS then
                     ShowArchaeologistLens()
                 end
             -- Deselection
             else
-                if unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHEOLOGIST_LENS then
+                if unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHAEOLOGIST_LENS then
                     ClearArchaeologistLens()
                 end
             end
@@ -99,7 +114,7 @@ local function OnUnitRemovedFromMap( playerID: number, unitID : number )
     local lens = {}
     LuaEvents.MinimapPanel_GetActiveModLens(lens)
     if playerID == localPlayer then
-        if lens[1] == LENS_NAME and AUTO_APPLY_ARCHEOLOGIST_LENS then
+        if lens[1] == LENS_NAME and AUTO_APPLY_ARCHAEOLOGIST_LENS then
             ClearArchaeologistLens()
         end
     end
@@ -110,7 +125,7 @@ function OnUnitCaptured( currentUnitOwner, unit, owningPlayer, capturingPlayer )
     local localPlayer = Game.GetLocalPlayer()
     if owningPlayer == localPlayer then
         local unitType = GetUnitTypeFromIDs(owningPlayer, unitID)
-        if unitType and unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHEOLOGIST_LENS then
+        if unitType and unitType == "UNIT_ARCHAEOLOGIST" and AUTO_APPLY_ARCHAEOLOGIST_LENS then
             ClearArchaeologistLens()
         end
     end
@@ -139,7 +154,11 @@ if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_ARCHAEOLOGIST_LENS"
     g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_TOOLTIP_ARCHAEOLOGIST_LENS_ARTIFACT",     UI.GetColorValue("COLOR_ARTIFACT_ARCH_LENS")},
-        {"LOC_TOOLTIP_ARCHAEOLOGIST_LENS_SHIPWRECK",    UI.GetColorValue("COLOR_SHIPWRECK_ARCH_LENS")}
+        {m_LensSettings["COLOR_ARCHAEOLOGIST_LENS_ARTIFACT"].KeyLabel, m_LensSettings["COLOR_ARCHAEOLOGIST_LENS_ARTIFACT"].ConfiguredColor},
+        {m_LensSettings["COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK"].KeyLabel, m_LensSettings["COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK"].ConfiguredColor}
     }
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/Lenses/Barbarian/ModLens_Barbarian.lua
+++ b/Lenses/Barbarian/ModLens_Barbarian.lua
@@ -1,5 +1,10 @@
+include("LensSupport")
 local LENS_NAME = "ML_BARBARIAN"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
+
+local m_LensSettings = {
+    ["COLOR_BARBARIAN_LENS_ENCAMPMENT"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_BARBARIAN_LENS_ENCAMPMENT"), KeyLabel = "LOC_HUD_BARBARIAN_LENS_ENCAMPMENT" }
+}
 
 -- ===========================================================================
 -- Barbarian Lens Support
@@ -22,7 +27,7 @@ local function OnGetColorPlotTable()
     local localPlayer   :number = Game.GetLocalPlayer()
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local BarbarianColor = UI.GetColorValue("COLOR_BARBARIAN_BARB_LENS")
+    local BarbarianColor = m_LensSettings["COLOR_BARBARIAN_LENS_ENCAMPMENT"].ConfiguredColor
     local IgnoreColor = UI.GetColorValue("COLOR_MORELENSES_GREY")
     local colorPlot:table = {}
     colorPlot[BarbarianColor] = {}
@@ -58,6 +63,7 @@ end
 local function OnInitialize()
     -- Nothing to do
 end
+
 ]]
 
 local BarbarianLensEntry = {
@@ -66,6 +72,16 @@ local BarbarianLensEntry = {
     Initialize = nil,
     GetColorPlotTable = OnGetColorPlotTable
 }
+
+-- ===========================================================================
+local function ML_OnSettingsInitialized()
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+-- ===========================================================================
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
 
 -- minimappanel.lua
 if g_ModLenses ~= nil then
@@ -77,6 +93,10 @@ if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_BARBARIAN_LENS"
     g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_TOOLTIP_BARBARIAN_LENS_ENCAPMENT", UI.GetColorValue("COLOR_BARBARIAN_BARB_LENS")}
+        {m_LensSettings["COLOR_BARBARIAN_LENS_ENCAMPMENT"].KeyLabel, m_LensSettings["COLOR_BARBARIAN_LENS_ENCAMPMENT"].ConfiguredColor}
     }
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/Lenses/Builder/BuilderLens_Config_Default.lua
+++ b/Lenses/Builder/BuilderLens_Config_Default.lua
@@ -1,6 +1,5 @@
 include("BuilderLens_Support")
 
-
 -- From GovernorSupport.lua
 -- modified to catch unappointed errors
 function GetAppointedGovernor(playerID:number, governorTypeIndex:number)
@@ -34,26 +33,14 @@ end
 -- Add rules for builder lens
 -- ===========================================================================
 
-local m_BuilderLens_PN  = UI.GetColorValue("COLOR_BUILDER_LENS_PN")
-local m_BuilderLens_PD  = UI.GetColorValue("COLOR_BUILDER_LENS_PD")
-local m_BuilderLens_P1  = UI.GetColorValue("COLOR_BUILDER_LENS_P1")
-local m_BuilderLens_P1N = UI.GetColorValue("COLOR_BUILDER_LENS_P1N")
-local m_BuilderLens_P2  = UI.GetColorValue("COLOR_BUILDER_LENS_P2")
-local m_BuilderLens_P3  = UI.GetColorValue("COLOR_BUILDER_LENS_P3")
-local m_BuilderLens_P4  = UI.GetColorValue("COLOR_BUILDER_LENS_P4")
-local m_BuilderLens_P5  = UI.GetColorValue("COLOR_BUILDER_LENS_P5")
-local m_BuilderLens_P6  = UI.GetColorValue("COLOR_BUILDER_LENS_P6")
-local m_BuilderLens_P7  = UI.GetColorValue("COLOR_BUILDER_LENS_P7")
-
-
 -- NATIONAL PARK
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_PN],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_PN"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         if pPlot:GetOwner() == localPlayer then
             if pPlot:IsNationalPark() then
-                return m_BuilderLens_PN
+                return GetColorForNothingPlot()
             end
         end
         return -1
@@ -62,7 +49,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_PN],
 
 -- RESOURCE
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P1],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P1"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         local pPlayer:table = Players[localPlayer]
@@ -70,22 +57,22 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P1],
             if playerHasDiscoveredResource(pPlayer, pPlot) then
                 if plotHasImprovement(pPlot) then
                     if plotHasCorrectImprovement(pPlot) then
-                        return m_BuilderLens_PN
+                        return GetColorForNothingPlot()
                     end
                 end
 
                 if plotResourceImprovable(pPlayer, pPlot) then
                     -- If the plot is within working range go ahead with correct highlight
                     if plotWithinWorkingRange(pPlayer, pPlot) then
-                        return m_BuilderLens_P1
+                        return GetConfiguredColor("COLOR_BUILDER_LENS_P1")
                     else
                         -- If the plot is outside working range, it is less important
                         -- We still might want to suggest it because of vital strategic resource / luxury, or a unique wonder
                         -- that can provide bonuses to it example (Temple of Artemis)
-                        return m_BuilderLens_P1N
+                        return GetConfiguredColor("COLOR_BUILDER_LENS_P1N")
                     end
                 else
-                    return m_BuilderLens_PN
+                    return GetColorForNothingPlot()
                 end
             end
         end
@@ -96,7 +83,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P1],
 -- GEOTHERMAL PLANTS (Only add if exists)
 --------------------------------------
 if GameInfo.Improvements["IMPROVEMENT_GEOTHERMAL_PLANT"] ~= nil then
-    table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
+    table.insert(GetConfigRules("COLOR_BUILDER_LENS_P2"),
         function(pPlot)
             local localPlayer = Game.GetLocalPlayer()
             local pPlayer:table = Players[localPlayer]
@@ -107,7 +94,7 @@ if GameInfo.Improvements["IMPROVEMENT_GEOTHERMAL_PLANT"] ~= nil then
                 if featureInfo.FeatureType == "FEATURE_GEOTHERMAL_FISSURE" then
                     local plantImprovInfo = GameInfo.Improvements["IMPROVEMENT_GEOTHERMAL_PLANT"]
                     if playerCanHave(pPlayer, plantImprovInfo) then
-                        return m_BuilderLens_P2
+                        return GetConfiguredColor("COLOR_BUILDER_LENS_P2")
                     end
                 end
             end
@@ -117,7 +104,7 @@ end
 
 -- SEASIDE RESORTS
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P2"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         local pPlayer:table = Players[localPlayer]
@@ -128,7 +115,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
                 and pPlot:GetImprovementType() ~= resortImprovInfo.Index then
 
             if plotCanHaveImprovement(pPlayer, pPlot, resortImprovInfo) then
-                return m_BuilderLens_P2
+                return GetConfiguredColor("COLOR_BUILDER_LENS_P2")
             end
         end
     end)
@@ -137,7 +124,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
 -- SKI RESORTS (Only add if exists)
 --------------------------------------
 if GameInfo.Improvements["IMPROVEMENT_SKI_RESORT"] ~= nil then
-    table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
+    table.insert(GetConfigRules("COLOR_BUILDER_LENS_P2"),
         function(pPlot)
             local localPlayer = Game.GetLocalPlayer()
             local pPlayer:table = Players[localPlayer]
@@ -147,7 +134,7 @@ if GameInfo.Improvements["IMPROVEMENT_SKI_RESORT"] ~= nil then
                 local resortImprovInfo = GameInfo.Improvements["IMPROVEMENT_SKI_RESORT"]
                 if plotCanHaveImprovement(pPlayer, pPlot, resortImprovInfo)
                         and not plotHasAdjImprovement(pPlot, "IMPROVEMENT_SKI_RESORT") then
-                    return m_BuilderLens_P2
+                    return GetConfiguredColor("COLOR_BUILDER_LENS_P2")
                 end
             end
         end)
@@ -156,12 +143,12 @@ end
 
 -- PILLAGED / UA
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P2"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         if pPlot:GetOwner() == localPlayer and not plotHasDistrict(pPlot) then
             if plotHasImprovement(pPlot) and pPlot:IsImprovementPillaged() then
-                return m_BuilderLens_P2
+                return GetConfiguredColor("COLOR_BUILDER_LENS_P2")
             end
         end
         return -1
@@ -170,33 +157,33 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P2],
 
 -- IGNORE PLOTS (Performance optimizations)
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P3"),
     function(pPlot)
         -- Non local player plots
         local localPlayer = Game.GetLocalPlayer()
         if pPlot:GetOwner() ~= localPlayer then
-            return -2  -- special flag to completely ignore coloring
+            return GetIgnorePlotColor()  -- special flag to completely ignore coloring
         end
 
         -- Districts. Assume unique abilities are handled earlier (P2 typically)
         if plotHasDistrict(pPlot) then
-            return m_BuilderLens_PN
+            return GetColorForNothingPlot()
         end
 
         -- If an improvement is here, assume we are done with this plot
         if plotHasImprovement(pPlot) then
-            return m_BuilderLens_PN
+            return GetColorForNothingPlot()
         end
 
         -- Mountains or impassable wonders
         if pPlot:IsImpassable() then
-            return m_BuilderLens_PN
+            return GetColorForNothingPlot()
         end
 
         -- Outside of working range can be ignored from here on out
         local pPlayer:table = Players[localPlayer]
         if not plotWithinWorkingRange(pPlayer, pPlot) then
-            return m_BuilderLens_PN
+            return GetColorForNothingPlot()
         end
     end)
 
@@ -204,7 +191,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
 -- RECOMMENDED PLOTS
 --------------------------------------
 -- These are generic plots, but have some buff on it that can make it desirable to improve
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P3"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         local pPlayer:table = Players[localPlayer]
@@ -212,7 +199,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
         if plotHasFeature(pPlot) then
             local featureInfo = GameInfo.Features[pPlot:GetFeatureType()]
             if featureInfo.NaturalWonder then
-                return m_BuilderLens_PN
+                return GetColorForNothingPlot()
             end
 
             -- 1. Non-hill woods next to river (lumbermill)
@@ -222,7 +209,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
                     and featureInfo.FeatureType == "FEATURE_FOREST" and pPlot:IsRiver()
                     and playerCanHave(pPlayer, lumberImprovInfo) then
 
-                return m_BuilderLens_P3
+                return GetConfiguredColor("COLOR_BUILDER_LENS_P3")
             end
 
             -- 2. Floodplains
@@ -230,7 +217,7 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
                 local farmImprovInfo = GameInfo.Improvements["IMPROVEMENT_FARM"]
                 local spitResult = Split(featureInfo.FeatureType, "_")
                 if #spitResult > 1 and spitResult[2] == "FLOODPLAINS" and playerCanHave(pPlayer, farmImprovInfo) then
-                    return m_BuilderLens_P3
+                    return GetConfiguredColor("COLOR_BUILDER_LENS_P3")
                 end
             ]]
 
@@ -238,18 +225,18 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
 
             -- 3. Volconic soil or tile next to buffing wonder
             if featureInfo.FeatureType == "FEATURE_VOLCANIC_SOIL" and canHaveImpr then
-                return m_BuilderLens_P3
+                return GetConfiguredColor("COLOR_BUILDER_LENS_P3")
             end
 
             -- 4. Wonder buffed tile
             if plotNextToBuffingWonder(pPlot) and canHaveImpr then
-                return m_BuilderLens_P3
+                return GetConfiguredColor("COLOR_BUILDER_LENS_P3")
             end
         end
 
         -- 5. Currently worked tile that does not have a improvement but can have one
         if plotWorkedByCitizen(pPlot) and plotCanHaveSomeImprovement(pPlayer, pPlot) then
-            return m_BuilderLens_P3
+            return GetConfiguredColor("COLOR_BUILDER_LENS_P3")
         end
         return -1
     end)
@@ -258,12 +245,12 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P3],
 -- HILLS
 --------------------------------------
 -- Typically hills have a base +1 Production hence any improvement on top of it is desirable
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P4],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P4"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         local pPlayer:table = Players[localPlayer]
         if pPlot:IsHills() and plotCanHaveSomeImprovement(pPlayer, pPlot) then
-            return m_BuilderLens_P4
+            return GetConfiguredColor("COLOR_BUILDER_LENS_P4")
         end
         return -1
     end)
@@ -271,12 +258,12 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P4],
 
 -- EXTRACTABLE FEATURE
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P5],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P5"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         local pPlayer:table = Players[localPlayer]
         if plotHasYieldExtractingFeature(pPlayer, pPlot) then
-            return m_BuilderLens_P5
+            return GetConfiguredColor("COLOR_BUILDER_LENS_P5")
         end
         return -1
     end)
@@ -284,16 +271,16 @@ table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P5],
 
 -- GENERIC (Last rule)
 --------------------------------------
-table.insert(g_ModLenses_Builder_Config[m_BuilderLens_P7],
+table.insert(GetConfigRules("COLOR_BUILDER_LENS_P7"),
     function(pPlot)
         local localPlayer = Game.GetLocalPlayer()
         local pPlayer:table = Players[localPlayer]
 
         -- Can we build any improvement add it here
         if plotCanHaveSomeImprovement(pPlayer, pPlot) then
-            return m_BuilderLens_P7
+            return GetConfiguredColor("COLOR_BUILDER_LENS_P7")
         end
 
         -- Assume at this point we can't do anything
-        return m_BuilderLens_PN
+        return GetColorForNothingPlot()
     end)

--- a/Lenses/Builder/BuilderLens_Support.lua
+++ b/Lenses/Builder/BuilderLens_Support.lua
@@ -1,5 +1,3 @@
-include("LensSupport")
-
 -- ===========================================================================
 -- Helpers
 -- ===========================================================================
@@ -419,7 +417,7 @@ function plotHasCorrectImprovement(pPlot:table)
 end
 
 function plotWorkedByCitizen(pPlot:table)
-    print("Checking worked by for " .. pPlot:GetIndex())
+    -- print("Checking worked by for " .. pPlot:GetIndex())
     return pPlot:GetWorkerCount() > 0
 end
 

--- a/Lenses/Builder/ModLens_Builder.lua
+++ b/Lenses/Builder/ModLens_Builder.lua
@@ -1,54 +1,82 @@
 include("LensSupport")
-
-local m_BuilderLens_PN = UI.GetColorValue("COLOR_BUILDER_LENS_PN")
-local m_BuilderLens_PD = UI.GetColorValue("COLOR_BUILDER_LENS_PD")
-local m_BuilderLens_P1 = UI.GetColorValue("COLOR_BUILDER_LENS_P1")
-local m_BuilderLens_P1N = UI.GetColorValue("COLOR_BUILDER_LENS_P1N")
-local m_BuilderLens_P2 = UI.GetColorValue("COLOR_BUILDER_LENS_P2")
-local m_BuilderLens_P3 = UI.GetColorValue("COLOR_BUILDER_LENS_P3")
-local m_BuilderLens_P4 = UI.GetColorValue("COLOR_BUILDER_LENS_P4")
-local m_BuilderLens_P5 = UI.GetColorValue("COLOR_BUILDER_LENS_P5")
-local m_BuilderLens_P6 = UI.GetColorValue("COLOR_BUILDER_LENS_P6")
-local m_BuilderLens_P7 = UI.GetColorValue("COLOR_BUILDER_LENS_P7")
-
-local m_FallbackColor = m_BuilderLens_PN
-
-local m_ModLenses_Builder_Priority = {
-    m_BuilderLens_PN,
-    m_BuilderLens_PD,
-    m_BuilderLens_P1,
-    m_BuilderLens_P2,
-    m_BuilderLens_P3,
-    m_BuilderLens_P4,
-    m_BuilderLens_P5,
-    m_BuilderLens_P6,
-    m_BuilderLens_P7,
+-- Note: Include for BuilderLens_Config and BuilderLens_Support occurs below, as supporting calls need to be added first
+-- Key: PN = Nothing    PD = Dangerous    P1 = Resources    P1N = Resources Outside Range    P2 = Recommended/Pillaged/Unique
+--      P3 = Currently Worked / Wonder-Buffed    P4 = Hills    P5 = Feature Extraction    P6 = Nothing(Disabled)    P7 = General
+local m_LensSettings = {
+    ["COLOR_BUILDER_LENS_PN"]  =  { Index = 0x01, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_PN"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_PN" },
+    ["COLOR_BUILDER_LENS_PD"]  =  { Index = 0x02, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_PD"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_PD" },
+    ["COLOR_BUILDER_LENS_P1"]  =  { Index = 0x10, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P1"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P1" },
+    ["COLOR_BUILDER_LENS_P1N"] =  { Index = 0x11, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P1N"), ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P1N"},
+    ["COLOR_BUILDER_LENS_P2"]  =  { Index = 0x20, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P2"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P2" },
+    ["COLOR_BUILDER_LENS_P3"]  =  { Index = 0x30, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P3"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P3" },
+    ["COLOR_BUILDER_LENS_P4"]  =  { Index = 0x40, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P4"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P4" },
+    ["COLOR_BUILDER_LENS_P5"]  =  { Index = 0x50, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P5"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P5" },
+    ["COLOR_BUILDER_LENS_P6"]  =  { Index = 0x60, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P6"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P6" },
+    ["COLOR_BUILDER_LENS_P7"]  =  { Index = 0x70, ConfiguredColor = GetLensColorFromSettings("COLOR_BUILDER_LENS_P7"),  ConfigRules = {}, KeyLabel = "LOC_HUD_BUILDER_LENS_P7" }
 }
 
-g_ModLenses_Builder_Config = {
-    [m_BuilderLens_PN] = {},
-    [m_BuilderLens_PD] = {},
-    [m_BuilderLens_P1] = {},
-    [m_BuilderLens_P2] = {},
-    [m_BuilderLens_P3] = {},
-    [m_BuilderLens_P4] = {},
-    [m_BuilderLens_P5] = {},
-    [m_BuilderLens_P6] = {},
-    [m_BuilderLens_P7] = {},
-}
+local m_LensSettings_SortedIndexMap = {}
+for k,v in pairs(m_LensSettings) do
+    table.insert(m_LensSettings_SortedIndexMap, {Index = m_LensSettings[k].Index, Key = k});
+end
+table.sort(m_LensSettings_SortedIndexMap, function(a,b) return a.Index < b.Index end)
 
+local DISABLE_NOTHING_PLOT_HIGHLIGHT:boolean = true;
+local AUTO_APPLY_BUILDER_LENS:boolean = true;
+local DISABLE_DANGEROUS_PLOT_HIGHLIGHT:boolean = false;
+local IGNORE_PLOT_COLOR:number = -2
+
+-- ==== Functions called by the "include" Files
+-- ===========================================================================
+function GetColorForNothingPlot()
+    if DISABLE_NOTHING_PLOT_HIGHLIGHT then
+        return IGNORE_PLOT_COLOR;
+    else
+        return m_LensSettings["COLOR_BUILDER_LENS_PN"].ConfiguredColor;
+    end
+end
+
+-- ===========================================================================
+function GetIgnorePlotColor()
+    return IGNORE_PLOT_COLOR;
+end
+
+-- ===========================================================================
+function GetConfigRules(lensName)
+    return m_LensSettings[lensName].ConfigRules;
+end
+
+-- ===========================================================================
+function GetConfiguredColor(lensName)
+    return m_LensSettings[lensName].ConfiguredColor;
+end
+
+-- ===========================================================================
 -- Import config files for builder lens
 include("BuilderLens_Config_", true)
+-- ===========================================================================
 
 local LENS_NAME = "ML_BUILDER"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
 
--- Should the builder lens auto apply, when a builder is selected.
-local AUTO_APPLY_BUILDER_LENS:boolean = GameConfiguration.GetValue("ML_AutoApplyBuilderLens")
--- Disables the nothing color being highlted by the builder
-local DISABLE_NOTHING_PLOT_HIGHLIGHT:boolean = GameConfiguration.GetValue("ML_BuilderLensDisableNothingHighlight")
--- Disables the dangerous plots highlted by the builder (barbs/military units at war with)
-local DISABLE_DANGEROUS_PLOT_HIGHLIGHT:boolean = GameConfiguration.GetValue("ML_BuilderLensDisableDangerousHighlight")
+-- ===========================================================================
+local function ML_OnSettingsInitialized()
+    -- Should the builder lens auto apply, when a builder is selected.
+    AUTO_APPLY_BUILDER_LENS = GameConfiguration.GetValue("ML_AutoApplyBuilderLens");
+    -- Disables the nothing color being highlted by the builder
+    DISABLE_NOTHING_PLOT_HIGHLIGHT = GameConfiguration.GetValue("ML_BuilderLensDisableNothingHighlight");
+    -- Disables the dangerous plots highlted by the builder (barbs/military units at war with)
+    DISABLE_DANGEROUS_PLOT_HIGHLIGHT = GameConfiguration.GetValue("ML_BuilderLensDisableDangerousHighlight");
+    print(AUTO_APPLY_BUILDER_LENS)
+    print(DISABLE_NOTHING_PLOT_HIGHLIGHT)
+    print(DISABLE_DANGEROUS_PLOT_HIGHLIGHT)
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+-- ===========================================================================
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
 
 -- ===========================================================================
 -- Exported functions
@@ -63,7 +91,8 @@ local function OnGetColorPlotTable()
 
     local colorPlot:table = {}
     local dangerousPlotsHash:table = {}
-    colorPlot[m_FallbackColor] = {}
+    local fallbackColorIndex = m_LensSettings["COLOR_BUILDER_LENS_PN"].Index;
+    colorPlot[fallbackColorIndex] = {}
 
     if not DISABLE_DANGEROUS_PLOT_HIGHLIGHT then
         -- Make hash of all dangerous plots
@@ -107,15 +136,15 @@ local function OnGetColorPlotTable()
         local pPlot:table = Map.GetPlotByIndex(i)
         if dangerousPlotsHash[i] == nil and localPlayerVis:IsRevealed(pPlot:GetX(), pPlot:GetY()) then
             local bPlotColored:boolean = false
-            for _, color in ipairs(m_ModLenses_Builder_Priority) do
-                config = g_ModLenses_Builder_Config[color]
+            for _, lensEntry in ipairs(m_LensSettings_SortedIndexMap) do
+                config = m_LensSettings[lensEntry.Key].ConfigRules
                 if config ~= nil and table.count(config) > 0 then
                     for _, rule in ipairs(config) do
                         if rule ~= nil then
                             ruleColor = rule(pPlot)
                             if ruleColor ~= nil and ruleColor ~= -1 then
                                 -- Catch special flag that says to completely ignore coloring
-                                if ruleColor == -2 then
+                                if ruleColor == IGNORE_PLOT_COLOR then
                                     bPlotColored = true
                                     break
                                 end
@@ -138,20 +167,17 @@ local function OnGetColorPlotTable()
             end
 
             if not bPlotColored and pPlot:GetOwner() == localPlayer then
-                table.insert(colorPlot[m_FallbackColor], i)
+                table.insert(colorPlot[fallbackColorIndex], i)
             end
         end
     end
 
-    if DISABLE_NOTHING_PLOT_HIGHLIGHT then
-        colorPlot[m_BuilderLens_PN] = nil
-    end
-
     if not DISABLE_DANGEROUS_PLOT_HIGHLIGHT then
         -- From hash build our colorPlot entry
-        colorPlot[m_BuilderLens_PD] = {}
+        local pdLensIndex = m_LensSettings["COLOR_BUILDER_LENS_PD"].Index;
+        colorPlot[pdLensIndex] = {}
         for iPlot, _ in pairs(dangerousPlotsHash) do
-            table.insert(colorPlot[m_BuilderLens_PD], iPlot)
+            table.insert(colorPlot[pdLensIndex], iPlot)
         end
     end
 
@@ -219,22 +245,11 @@ local function OnUnitRemovedFromMap( playerID: number, unitID : number )
     end
 end
 
-local function OnLensSettingsUpdate()
-    -- Refresh our local settings from updated GameConfig
-    AUTO_APPLY_BUILDER_LENS = GameConfiguration.GetValue("ML_AutoApplyBuilderLens")
-    DISABLE_NOTHING_PLOT_HIGHLIGHT = GameConfiguration.GetValue("ML_BuilderLensDisableNothingHighlight")
-    DISABLE_DANGEROUS_PLOT_HIGHLIGHT = GameConfiguration.GetValue("ML_BuilderLensDisableDangerousHighlight")
-    print(AUTO_APPLY_BUILDER_LENS)
-    print(DISABLE_NOTHING_PLOT_HIGHLIGHT)
-    print(DISABLE_DANGEROUS_PLOT_HIGHLIGHT)
-end
-
 local function OnInitialize()
     Events.UnitSelectionChanged.Add( OnUnitSelectionChanged );
     Events.UnitCaptured.Add( OnUnitCaptured );
     Events.UnitChargesChanged.Add( OnUnitChargesChanged );
     Events.UnitRemovedFromMap.Add( OnUnitRemovedFromMap );
-    LuaEvents.ML_SettingsUpdate.Add( OnLensSettingsUpdate )
 end
 
 local BuilderLensEntry = {
@@ -253,18 +268,16 @@ end
 if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_BUILDER_LENS"
-
-    -- TODO: Make this automatic based on added rules
-    g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_HUD_BUILDER_LENS_PN", m_BuilderLens_PN},
-        {"LOC_HUD_BUILDER_LENS_PD", m_BuilderLens_PD},
-        {"LOC_HUD_BUILDER_LENS_P1", m_BuilderLens_P1},
-        {"LOC_HUD_BUILDER_LENS_P1N", m_BuilderLens_P1N},
-        {"LOC_HUD_BUILDER_LENS_P2", m_BuilderLens_P2},
-        {"LOC_HUD_BUILDER_LENS_P3", m_BuilderLens_P3},
-        {"LOC_HUD_BUILDER_LENS_P4", m_BuilderLens_P4},
-        {"LOC_HUD_BUILDER_LENS_P5", m_BuilderLens_P5},
-        -- {"LOC_HUD_BUILDER_LENS_P6", m_BuilderLens_P6},
-        {"LOC_HUD_BUILDER_LENS_P7", m_BuilderLens_P7},
-    }
+    g_ModLensModalPanel[LENS_NAME].Legend = {}
+    -- Insert in priority order and only those with Rules that do coloring
+    for _,lensInfo in ipairs(m_LensSettings_SortedIndexMap) do
+        local lensData = m_LensSettings[lensInfo.Key];
+        if (#lensData.ConfigRules > 0) then
+            table.insert(g_ModLensModalPanel[LENS_NAME].Legend, {lensData.KeyLabel, lensData.ConfiguredColor});
+        end
+    end
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/Lenses/CityOverlap/ModLens_CityOverlap.lua
+++ b/Lenses/CityOverlap/ModLens_CityOverlap.lua
@@ -16,6 +16,18 @@ local m_isOpen:boolean = false
 local m_cityOverlapRange:number = DEFAULT_OVERLAP_RANGE
 local m_currentCursorPlotID:number = -1
 
+local m_LensSettings = {
+    -- Note the special case handling with the KeyLabel
+    ["COLOR_CITYOVERLAP_LENS_1"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_1"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +1" },
+    ["COLOR_CITYOVERLAP_LENS_2"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_2"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +2" },
+    ["COLOR_CITYOVERLAP_LENS_3"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_3"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +3" },
+    ["COLOR_CITYOVERLAP_LENS_4"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_4"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +4" },
+    ["COLOR_CITYOVERLAP_LENS_5"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_5"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +5" },
+    ["COLOR_CITYOVERLAP_LENS_6"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_6"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +6" },
+    ["COLOR_CITYOVERLAP_LENS_7"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_7"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +7" },
+    ["COLOR_CITYOVERLAP_LENS_8"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_8"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +8" }
+}
+
 -- ===========================================================================
 --  City Overlap Support functions
 -- ===========================================================================
@@ -55,10 +67,11 @@ local function SetModalKey(maxCityOverlap)
     local CityOverlapLensModalPanelEntry = {}
     CityOverlapLensModalPanelEntry.Legend = {}
     CityOverlapLensModalPanelEntry.LensTextKey = "LOC_HUD_CITYOVERLAP_LENS"
+    -- NOTE: Not using the KeyLabel here, in order to place the bonus value on the next line
     for i = 1, 8 do
         local params:table = {
             "LOC_WORLDBUILDER_TAB_CITIES",
-            UI.GetColorValue("COLOR_GRADIENT8_" .. tostring(i)),
+            m_LensSettings["COLOR_CITYOVERLAP_LENS_" .. tostring(i)].ConfiguredColor,
             nil,  -- bonus icon
             "+ " .. tostring(i + (maxCityOverlap - 8))  -- bonus value
         }
@@ -122,8 +135,8 @@ local function SetCityOverlapLens()
         local relativeNumCities:number = numCityEntries[i] - cityOffset
 
         if relativeNumCities > 0 then
-            local colorLookup:string = "COLOR_GRADIENT8_" .. tostring(relativeNumCities)
-            local color:number = UI.GetColorValue(colorLookup)
+            local colorLookup:string = "COLOR_CITYOVERLAP_LENS_" .. tostring(relativeNumCities)
+            local color:number = m_LensSettings[colorLookup].ConfiguredColor
             UILens.SetLayerHexesColoredArea( ML_LENS_LAYER, localPlayer, {plotEntries[i]}, color )
         end
     end
@@ -153,12 +166,12 @@ local function SetRangeMouseLens(range)
     end
 
     if (table.count(cityPlots) > 0) then
-        local plotColor:number = UI.GetColorValue("COLOR_GRADIENT8_1")
+        local plotColor:number = m_LensSettings["COLOR_CITYOVERLAP_LENS_1"].ConfiguredColor
         UILens.SetLayerHexesColoredArea( ML_LENS_LAYER, localPlayer, cityPlots, plotColor )
     end
 
     if (table.count(normalPlot) > 0) then
-        local plotColor:number = UI.GetColorValue("COLOR_GRADIENT8_3")
+        local plotColor:number = m_LensSettings["COLOR_CITYOVERLAP_LENS_3"].ConfiguredColor
         UILens.SetLayerHexesColoredArea( ML_LENS_LAYER, localPlayer, normalPlot, plotColor )
     end
 end
@@ -284,6 +297,17 @@ local function OnShutdown()
     end
 end
 
+local function ML_OnSettingsInitialized()
+    -- NOTE: Do not update the g_ModLensModalPanel directly, use the local function to handle that
+    --       as it has special-case handling for the Modal Panel key text
+    UpdateLensConfiguredColors(m_LensSettings, nil, LENS_NAME);
+    SetModalKey(maxCityOverlap);
+end
+
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
+
 -- ===========================================================================
 --  Init
 -- ===========================================================================
@@ -296,6 +320,10 @@ local CityOverlapLensEntry = {
     OnToggle = TogglePanel,
     GetColorPlotTable = nil  -- Pass nil since we have our own trigger
 }
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);
 
 -- Don't import this into g_ModLenses, since this for the UI (ie not lens)
 local function Initialize()

--- a/Lenses/LensSupport.lua
+++ b/Lenses/LensSupport.lua
@@ -430,3 +430,46 @@ end
         end
     end
 -- End of iterator code --------------------
+
+function GetLensColorFromSettings(lensName)
+    -- A lens color can be set by the ML Settings elements
+    local lensData = GameConfiguration.GetValue(lensName);
+    if (lensData == nil) then
+        lensData = GameInfo.Colors[lensName];
+        if (lensData == nil) then
+            lensData = {}
+            lensData["Red"] = 0;
+            lensData["Blue"] = 0;
+            lensData["Green"] = 0;
+        end
+
+        GameConfiguration.SetValue(lensName, lensData);
+    end
+
+    return UI.GetColorValue(lensData["Red"], lensData["Green"], lensData["Blue"]);
+end
+
+-- lensEntitiesTable is a list of Lens Entities (Colors) for that Particular Lens
+-- modLensModalPanelTable is the table used by modalpanel.lua to construct the Key table for any lens
+-- lens_name is the LENS_NAME value from that lens
+function UpdateLensConfiguredColors(lensEntitiesTable, modLensModalPanelTable, lens_name)
+    -- Called whenever we want to force the Lens Colors to be refreshed
+    -- GetLensColorFromSettings will get the value if stored by GameConfiguration.SetValue,
+    -- otherwise it will load the value from the GameInfo.Colors table that was updated by the MoreLenses SQL file
+    for lensKey, lensConfig in pairs(lensEntitiesTable) do
+        lensColor = GetLensColorFromSettings(lensKey);
+        lensEntitiesTable[lensKey].ConfiguredColor = lensColor;
+        -- Not sure there's a better way to do this and also keep the structure of g_ModLensModalPanel?
+        -- defined only by modellenspanel.lua, so only gets called when in the modellenspanel context
+        if modLensModalPanelTable ~= nil then
+            lensLegend = modLensModalPanelTable[lens_name].Legend;
+            for idx, entry in ipairs(modLensModalPanelTable[lens_name].Legend) do
+                locVal, colorVal = unpack(entry);
+                if locVal == lensEntitiesTable[lensKey].KeyLabel then
+                    modLensModalPanelTable[lens_name].Legend[idx] = {lensEntitiesTable[lensKey].KeyLabel, lensColor};
+                    break;
+                end
+            end
+        end
+    end
+end

--- a/Lenses/Naturalist/ModLens_Naturalist.lua
+++ b/Lenses/Naturalist/ModLens_Naturalist.lua
@@ -3,6 +3,12 @@ include("LensSupport")
 local LENS_NAME = "ML_NATURALIST"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
 
+local m_LensSettings = {
+    ["COLOR_NATURALIST_LENS_PARK"] =    { ConfiguredColor = GetLensColorFromSettings("COLOR_NATURALIST_LENS_PARK"),    KeyLabel = "LOC_HUD_NATURALIST_LENS_PARK" },
+    ["COLOR_NATURALIST_LENS_OK"]  =     { ConfiguredColor = GetLensColorFromSettings("COLOR_NATURALIST_LENS_OK"),      KeyLabel = "LOC_HUD_NATURALIST_LENS_OK" },
+    ["COLOR_NATURALIST_LENS_FIXABLE"] = { ConfiguredColor = GetLensColorFromSettings("COLOR_NATURALIST_LENS_FIXABLE"), KeyLabel = "LOC_HUD_NATURALIST_LENS_FIXABLE" }
+}
+
 -- ===========================================================================
 -- Naturalist Lens Support
 -- ===========================================================================
@@ -36,9 +42,9 @@ local function OnGetColorPlotTable()
     local localPlayer:number = Game.GetLocalPlayer()
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local parkPlotColor:number = UI.GetColorValue("COLOR_PARK_NATURALIST_LENS")
-    local OkColor:number = UI.GetColorValue("COLOR_OK_NATURALIST_LENS")
-    local FixableColor:number = UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS")
+    local parkPlotColor:number = m_LensSettings["COLOR_NATURALIST_LENS_PARK"].ConfiguredColor
+    local OkColor:number =       m_LensSettings["COLOR_NATURALIST_LENS_OK"].ConfiguredColor
+    local FixableColor:number =  m_LensSettings["COLOR_NATURALIST_LENS_FIXABLE"].ConfiguredColor
 
     local colorPlot = {}
     colorPlot[OkColor] = {}
@@ -195,7 +201,7 @@ local function ClearNaturalistLens()
 end
 
 local function OnInitialize()
-    -- Nothing to do
+  -- Nothing to do
 end
 ]]
 
@@ -205,6 +211,16 @@ local NaturalistLensEntry = {
     Initialize = nil,
     GetColorPlotTable = OnGetColorPlotTable
 }
+
+-- ===========================================================================
+local function ML_OnSettingsInitialized()
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+-- ===========================================================================
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
 
 -- minimappanel.lua
 if g_ModLenses ~= nil then
@@ -216,8 +232,12 @@ if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_NATURALIST_LENS"
     g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_TOOLTIP_NATURALIST_LENS_NPARK", UI.GetColorValue("COLOR_PARK_NATURALIST_LENS")},
-        {"LOC_TOOLTIP_NATURALIST_LENS_OK", UI.GetColorValue("COLOR_OK_NATURALIST_LENS")},
-        {"LOC_TOOLTIP_NATURALIST_LENS_FIXABLE", UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS")}
+        {m_LensSettings["COLOR_NATURALIST_LENS_PARK"].KeyLabel, m_LensSettings["COLOR_NATURALIST_LENS_PARK"].ConfiguredColor},
+        {m_LensSettings["COLOR_NATURALIST_LENS_OK"].KeyLabel, m_LensSettings["COLOR_NATURALIST_LENS_OK"].ConfiguredColor},
+        {m_LensSettings["COLOR_NATURALIST_LENS_FIXABLE"].KeyLabel, m_LensSettings["COLOR_NATURALIST_LENS_FIXABLE"].ConfiguredColor}
     }
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/Lenses/Resource/ModLens_Resource.lua
+++ b/Lenses/Resource/ModLens_Resource.lua
@@ -28,18 +28,27 @@ local m_resourceExclusionList:table = {
     "RESOURCE_SHIPWRECK"
 }
 
+local m_LensSettings = {
+    ["COLOR_RESOURCE_LENS_LUXCONNECTED"]    =  { ConfiguredColor = GetLensColorFromSettings("COLOR_RESOURCE_LENS_LUXCONNECTED"),    KeyLabel = "LOC_HUD_RESOURCE_LENS_LUXCONNECTED" },
+    ["COLOR_RESOURCE_LENS_STRATCONNECTED"]  =  { ConfiguredColor = GetLensColorFromSettings("COLOR_RESOURCE_LENS_STRATCONNECTED"),  KeyLabel = "LOC_HUD_RESOURCE_LENS_STRATCONNECTED" },
+    ["COLOR_RESOURCE_LENS_BONUSCONNECTED"]  =  { ConfiguredColor = GetLensColorFromSettings("COLOR_RESOURCE_LENS_BONUSCONNECTED"),  KeyLabel = "LOC_HUD_RESOURCE_LENS_BONUSCONNECTED" },
+    ["COLOR_RESOURCE_LENS_LUXNCONNECTED"]   =  { ConfiguredColor = GetLensColorFromSettings("COLOR_RESOURCE_LENS_LUXNCONNECTED"),   KeyLabel = "LOC_HUD_RESOURCE_LENS_LUXNCONNECTED" },
+    ["COLOR_RESOURCE_LENS_STRATNCONNECTED"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_RESOURCE_LENS_STRATNCONNECTED"), KeyLabel = "LOC_HUD_RESOURCE_LENS_STRATNCONNECTED" },
+    ["COLOR_RESOURCE_LENS_BONUSNCONNECTED"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_RESOURCE_LENS_BONUSNCONNECTED"), KeyLabel = "LOC_HUD_RESOURCE_LENS_BONUSNCONNECTED" }
+}
+
 -- ===========================================================================
 --  Resource Support functions
 -- ===========================================================================
 
 local function ShowResourceLens()
-    print("Showing " .. LENS_NAME)
+    -- print("Showing " .. LENS_NAME)
     LuaEvents.MinimapPanel_SetActiveModLens(LENS_NAME)
     UILens.ToggleLayerOn(ML_LENS_LAYER)
 end
 
 local function ClearResourceLens()
-    print("Clearing " .. LENS_NAME)
+    -- print("Clearing " .. LENS_NAME)
     if UILens.IsLayerOn(ML_LENS_LAYER) then
         UILens.ToggleLayerOff(ML_LENS_LAYER)
     else
@@ -387,12 +396,12 @@ function SetResourceLens()
     local pPlayer:table = Players[localPlayer]
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local LuxConnectedColor   :number = UI.GetColorValue("COLOR_LUXCONNECTED_RES_LENS")
-    local StratConnectedColor :number = UI.GetColorValue("COLOR_STRATCONNECTED_RES_LENS")
-    local BonusConnectedColor :number = UI.GetColorValue("COLOR_BONUSCONNECTED_RES_LENS")
-    local LuxNConnectedColor  :number = UI.GetColorValue("COLOR_LUXNCONNECTED_RES_LENS")
-    local StratNConnectedColor  :number = UI.GetColorValue("COLOR_STRATNCONNECTED_RES_LENS")
-    local BonusNConnectedColor  :number = UI.GetColorValue("COLOR_BONUSNCONNECTED_RES_LENS")
+    local LuxConnectedColor   :number = m_LensSettings["COLOR_RESOURCE_LENS_LUXCONNECTED"].ConfiguredColor
+    local StratConnectedColor :number = m_LensSettings["COLOR_RESOURCE_LENS_STRATCONNECTED"].ConfiguredColor
+    local BonusConnectedColor :number = m_LensSettings["COLOR_RESOURCE_LENS_BONUSCONNECTED"].ConfiguredColor
+    local LuxNConnectedColor  :number = m_LensSettings["COLOR_RESOURCE_LENS_LUXNCONNECTED"].ConfiguredColor
+    local StratNConnectedColor:number = m_LensSettings["COLOR_RESOURCE_LENS_STRATNCONNECTED"].ConfiguredColor
+    local BonusNConnectedColor:number = m_LensSettings["COLOR_RESOURCE_LENS_BONUSNCONNECTED"].ConfiguredColor
     local IgnoreColor         :number = UI.GetColorValue("COLOR_MORELENSES_GREY")
 
     local ConnectedLuxury       = {}
@@ -472,6 +481,9 @@ function SetResourceLens()
     if table.count(IgnorePlots) > 0 then
         UILens.SetLayerHexesColoredArea( ML_LENS_LAYER, localPlayer, IgnorePlots, IgnoreColor )
     end
+
+    -- This takes care of updating the colors in the Modal Lens Key Panel
+    SetModalKeyResourceLens()
 end
 
 function RefreshResourcePicker()
@@ -795,6 +807,16 @@ local function ChangeContainer()
     Controls.ResourceLensOptionsPanel:ChangeParent(hudContainer)
 end
 
+local function ML_OnSettingsInitialized()
+    -- NOTE: This lens uses a special case to do the color key for the Modal Lens panel (as this lens is its own Context)
+    -- It will update the modal panel key when function to show the lens is called
+    UpdateLensConfiguredColors(m_LensSettings, nil, LENS_NAME);
+end
+
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
+
 local function OnInit(isReload:boolean)
     if isReload then
         ChangeContainer()
@@ -823,16 +845,25 @@ local ResourceLensEntry = {
 }
 
 -- modallenspanel.lua
+function SetModalKeyResourceLens()
 local ResourceLensModalPanelEntry = {}
 ResourceLensModalPanelEntry.LensTextKey = "LOC_HUD_RESOURCE_LENS"
 ResourceLensModalPanelEntry.Legend = {
-    {"LOC_TOOLTIP_RESOURCE_LENS_LUXURY",        UI.GetColorValue("COLOR_LUXCONNECTED_RES_LENS")},
-    {"LOC_TOOLTIP_RESOURCE_LENS_NLUXURY",       UI.GetColorValue("COLOR_LUXNCONNECTED_RES_LENS")},
-    {"LOC_TOOLTIP_RESOURCE_LENS_BONUS",         UI.GetColorValue("COLOR_BONUSCONNECTED_RES_LENS")},
-    {"LOC_TOOLTIP_RESOURCE_LENS_NBONUS",        UI.GetColorValue("COLOR_BONUSNCONNECTED_RES_LENS")},
-    {"LOC_TOOLTIP_RESOURCE_LENS_STRATEGIC",     UI.GetColorValue("COLOR_STRATCONNECTED_RES_LENS")},
-    {"LOC_TOOLTIP_RESOURCE_LENS_NSTRATEGIC",    UI.GetColorValue("COLOR_STRATNCONNECTED_RES_LENS")}
+    {m_LensSettings["COLOR_RESOURCE_LENS_LUXCONNECTED"].KeyLabel, m_LensSettings["COLOR_RESOURCE_LENS_LUXCONNECTED"].ConfiguredColor},
+    {m_LensSettings["COLOR_RESOURCE_LENS_LUXNCONNECTED"].KeyLabel, m_LensSettings["COLOR_RESOURCE_LENS_LUXNCONNECTED"].ConfiguredColor},
+    {m_LensSettings["COLOR_RESOURCE_LENS_BONUSCONNECTED"].KeyLabel, m_LensSettings["COLOR_RESOURCE_LENS_BONUSCONNECTED"].ConfiguredColor},
+    {m_LensSettings["COLOR_RESOURCE_LENS_BONUSNCONNECTED"].KeyLabel, m_LensSettings["COLOR_RESOURCE_LENS_BONUSNCONNECTED"].ConfiguredColor},
+    {m_LensSettings["COLOR_RESOURCE_LENS_STRATCONNECTED"].KeyLabel, m_LensSettings["COLOR_RESOURCE_LENS_STRATCONNECTED"].ConfiguredColor},
+    {m_LensSettings["COLOR_RESOURCE_LENS_STRATNCONNECTED"].KeyLabel, m_LensSettings["COLOR_RESOURCE_LENS_STRATNCONNECTED"].ConfiguredColor}
 }
+
+    -- -- overwrite the old entry and refresh key panel
+    LuaEvents.ModalLensPanel_AddLensEntry(LENS_NAME, ResourceLensModalPanelEntry, true)
+end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);
 
 -- Don't import this into g_ModLenses, since this for the UI (ie not lens)
 local function Initialize()
@@ -850,7 +881,7 @@ local function Initialize()
         function()
             ChangeContainer()
             LuaEvents.MinimapPanel_AddLensEntry(LENS_NAME, ResourceLensEntry)
-            LuaEvents.ModalLensPanel_AddLensEntry(LENS_NAME, ResourceLensModalPanelEntry)
+            SetModalKeyResourceLens()
         end
     )
     Events.LensLayerOn.Add( OnLensLayerOn )

--- a/Lenses/Scout/ModLens_Scout.lua
+++ b/Lenses/Scout/ModLens_Scout.lua
@@ -1,9 +1,27 @@
+include("LensSupport")
 local LENS_NAME = "ML_SCOUT"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
 
+local m_LensSettings = {
+    ["COLOR_SCOUT_LENS_GHUT"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_SCOUT_LENS_GHUT"), KeyLabel = "LOC_HUD_SCOUT_LENS_GHUT" }
+}
+
 -- Should the scout lens auto apply, when a scout/ranger is selected.
-local AUTO_APPLY_SCOUT_LENS:boolean = GameConfiguration.GetValue("ML_AutoApplyScoutLens")
-local AUTO_APPLY_SCOUT_LENS_EXTRA:boolean = GameConfiguration.GetValue("ML_AutoApplyScoutLensExtra")
+local AUTO_APPLY_SCOUT_LENS:boolean = true; 
+-- Should the scout lens auto-apply with any military unit
+local AUTO_APPLY_SCOUT_LENS_EXTRA:boolean = false;
+
+local function ML_OnSettingsInitialized()
+    -- Should the builder lens auto apply, when a builder is selected.
+    AUTO_APPLY_SCOUT_LENS = GameConfiguration.GetValue("ML_AutoApplyScoutLens");
+    AUTO_APPLY_SCOUT_LENS_EXTRA = GameConfiguration.GetValue("ML_AutoApplyScoutLensExtra");
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
+
 
 -- ===========================================================================
 -- Scout Lens Support
@@ -27,7 +45,7 @@ local function OnGetColorPlotTable()
     local localPlayer   :number = Game.GetLocalPlayer()
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local GoodyHutColor   :number = UI.GetColorValue("COLOR_GHUT_SCOUT_LENS")
+    local GoodyHutColor   :number = m_LensSettings["COLOR_SCOUT_LENS_GHUT"].ConfiguredColor
     local colorPlot = {}
     colorPlot[GoodyHutColor] = {}
 
@@ -140,7 +158,6 @@ local function OnInitialize()
     Events.UnitRemovedFromMap.Add( OnUnitRemovedFromMap )
     Events.UnitMoveComplete.Add( OnUnitMoveComplete )
     Events.GoodyHutReward.Add( OnGoodyHutReward )
-    LuaEvents.ML_SettingsUpdate.Add( OnLensSettingsUpdate )
 end
 
 local ScoutLensEntry = {
@@ -160,6 +177,10 @@ if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_SCOUT_LENS"
     g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_TOOLTIP_SCOUT_LENS_GHUT", UI.GetColorValue("COLOR_GHUT_SCOUT_LENS")}
+        {m_LensSettings["COLOR_SCOUT_LENS_GHUT"].KeyLabel, m_LensSettings["COLOR_SCOUT_LENS_GHUT"].ConfiguredColor}
     }
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/Lenses/UnitAction/ModLens_UnitAction.lua
+++ b/Lenses/UnitAction/ModLens_UnitAction.lua
@@ -1,8 +1,13 @@
+include("LensSupport")
 local LENS_NAME = "ML_UNITACTION"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
 
 -- Should the scout lens auto apply, when a scout/ranger is selected.
 local AUTO_APPLY_SCOUT_LENS:boolean = true
+
+local m_LensSettings = {
+    ["COLOR_SCOUT_LENS_GHUT"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_SCOUT_LENS_GHUT"), KeyLabel = "LOC_HUD_SCOUT_LENS_GHUT" }
+}
 
 -- ===========================================================================
 -- Scout Lens Support
@@ -26,7 +31,7 @@ local function OnGetColorPlotTable()
     local localPlayer   :number = Game.GetLocalPlayer()
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local GoodyHutColor   :number = UI.GetColorValue("COLOR_GHUT_SCOUT_LENS")
+    local GoodyHutColor   :number = m_LensSettings["COLOR_SCOUT_LENS_GHUT"].ConfiguredColor
     local colorPlot = {}
     colorPlot[GoodyHutColor] = {}
 
@@ -116,6 +121,14 @@ local function OnGoodyHutReward( playerID:number )
     end
 end
 
+local function ML_OnSettingsInitialized()
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
+
 local function OnInitialize()
     Events.UnitSelectionChanged.Add( OnUnitSelectionChanged )
     Events.UnitRemovedFromMap.Add( OnUnitRemovedFromMap )
@@ -140,6 +153,10 @@ if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_SCOUT_LENS"
     g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_TOOLTIP_SCOUT_LENS_GHUT", UI.GetColorValue("COLOR_GHUT_SCOUT_LENS")}
+        {m_LensSettings["COLOR_SCOUT_LENS_GHUT"].KeyLabel, m_LensSettings["COLOR_SCOUT_LENS_GHUT"].ConfiguredColor}
     }
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/Lenses/Wonder/ModLens_Wonder.lua
+++ b/Lenses/Wonder/ModLens_Wonder.lua
@@ -2,6 +2,10 @@ include("LensSupport")
 
 local LENS_NAME = "ML_WONDER"
 local ML_LENS_LAYER = UILens.CreateLensLayerHash("Hex_Coloring_Appeal_Level")
+local m_LensSettings = {
+    ["COLOR_WONDER_LENS_NATURAL"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_WONDER_LENS_NATURAL"), KeyLabel = "LOC_HUD_WONDER_LENS_NATURAL" },
+    ["COLOR_WONDER_LENS_PLAYER"]  =  { ConfiguredColor = GetLensColorFromSettings("COLOR_WONDER_LENS_PLAYER"),  KeyLabel = "LOC_HUD_WONDER_LENS_PLAYER" }
+}
 
 -- ===========================================================================
 -- Wonder Lens Support
@@ -16,8 +20,8 @@ local function OnGetColorPlotTable()
     local localPlayer   :number = Game.GetLocalPlayer()
     local localPlayerVis:table = PlayersVisibility[localPlayer]
 
-    local NaturalWonderColor  :number = UI.GetColorValue("COLOR_NATURAL_WONDER_LENS")
-    local PlayerWonderColor   :number = UI.GetColorValue("COLOR_PLAYER_WONDER_LENS")
+    local NaturalWonderColor  :number = m_LensSettings["COLOR_WONDER_LENS_NATURAL"].ConfiguredColor
+    local PlayerWonderColor   :number = m_LensSettings["COLOR_WONDER_LENS_PLAYER"].ConfiguredColor
     local IgnoreColor = UI.GetColorValue("COLOR_MORELENSES_GREY")
     local colorPlot:table = {}
     colorPlot[NaturalWonderColor] = {}
@@ -63,6 +67,16 @@ local function OnInitialize()
 end
 ]]
 
+-- ===========================================================================
+local function ML_OnSettingsInitialized()
+    UpdateLensConfiguredColors(m_LensSettings, g_ModLensModalPanel, LENS_NAME);
+end
+
+-- ===========================================================================
+local function ML_OnSettingsUpdate()
+    ML_OnSettingsInitialized();
+end
+
 local WonderLensEntry = {
     LensButtonText = "LOC_HUD_WONDER_LENS",
     LensButtonTooltip = "LOC_HUD_WONDER_LENS_TOOLTIP",
@@ -80,7 +94,11 @@ if g_ModLensModalPanel ~= nil then
     g_ModLensModalPanel[LENS_NAME] = {}
     g_ModLensModalPanel[LENS_NAME].LensTextKey = "LOC_HUD_WONDER_LENS"
     g_ModLensModalPanel[LENS_NAME].Legend = {
-        {"LOC_TOOLTIP_WONDER_LENS_NWONDER", UI.GetColorValue("COLOR_NATURAL_WONDER_LENS")},
-        {"LOC_TOOLTIP_RESOURCE_LENS_PWONDER", UI.GetColorValue("COLOR_PLAYER_WONDER_LENS")}
+        {m_LensSettings["COLOR_WONDER_LENS_NATURAL"].KeyLabel, m_LensSettings["COLOR_WONDER_LENS_NATURAL"].ConfiguredColor},
+        {m_LensSettings["COLOR_WONDER_LENS_PLAYER"].KeyLabel, m_LensSettings["COLOR_WONDER_LENS_PLAYER"].ConfiguredColor}
     }
 end
+
+-- Add ML LuaEvent Hooks for minimappanel and modallenspanel contexts
+LuaEvents.ML_SettingsUpdate.Add(ML_OnSettingsUpdate);
+LuaEvents.ML_SettingsInitialized.Add(ML_OnSettingsInitialized);

--- a/MoreLenses_Colors.sql
+++ b/MoreLenses_Colors.sql
@@ -36,72 +36,74 @@ INSERT INTO Colors      (   Type,                               Red,        Gree
 VALUES                  (   'COLOR_BUILDER_LENS_PN',            '0.33',     '0.33',     '0.33',     '0.5');
 
 -- Archeologist lens
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_ARTIFACT_ARCH_LENS',         '1',        '0',        '0',        '0.5');
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_SHIPWRECK_ARCH_LENS',        '0',        '1',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_ARCHAEOLOGIST_LENS_ARTIFACT',  '1',      '0',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK', '0',      '1',        '0',        '0.5');
 
 -- Gradient 8
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_1',                '0.9',      '0.0',      '0.05',     '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_1',         '0.9',      '0.0',      '0.05',     '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_2',                '0.8',      '0.48',     '0.0',      '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_2',         '0.8',      '0.48',     '0.0',      '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_3',                '0.75',     '0.75',     '0.75',     '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_3',         '0.75',     '0.75',     '0.75',     '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_4',                '0.5',      '1',        '0.5',      '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_4',         '0.5',      '1',        '0.5',      '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_5',                '0',        '1',        '0',        '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_5',         '0',        '1',        '0',        '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_6',                '0.0',      '0.98',     '0.93',     '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_6',         '0.0',      '0.98',     '0.93',     '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_7',                '0.56',     '0.0',      '0.98',     '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_7',         '0.56',     '0.0',      '0.98',     '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GRADIENT8_8',                '0.98',     '0.0',      '0.81',     '0.5');
+VALUES                  (   'COLOR_CITYOVERLAP_LENS_8',         '0.98',     '0.0',      '0.81',     '0.5');
 
 -- Barbarian Lens
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_BARBARIAN_BARB_LENS',        '1',        '0',        '0',        '0.5');
+VALUES                  (   'COLOR_BARBARIAN_LENS_ENCAMPMENT',  '1',        '0',        '0',        '0.5');
 
 -- Resources Lens
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_LUXCONNECTED_RES_LENS',      '0.82',     '0.65',     '0.96',     '0.5');
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_LUXNCONNECTED_RES_LENS',     '1',        '0',        '1',        '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_RESOURCE_LENS_LUXCONNECTED',   '0.82',   '0.65',     '0.96',     '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha) 
+VALUES                  (   'COLOR_RESOURCE_LENS_LUXNCONNECTED',  '1',      '0',        '1',        '0.5');
 
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_STRATCONNECTED_RES_LENS',    '0.96',     '0.54',     '0.54',     '0.5');
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_STRATNCONNECTED_RES_LENS',   '1',        '0',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_RESOURCE_LENS_STRATCONNECTED', '0.96',   '0.54',     '0.54',     '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_RESOURCE_LENS_STRATNCONNECTED','1',      '0',        '0',        '0.5');
 
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_BONUSCONNECTED_RES_LENS',    '0.5',      '1',        '0.5',      '0.5');
-INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_BONUSNCONNECTED_RES_LENS',   '0',        '1',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_RESOURCE_LENS_BONUSCONNECTED', '0.5',    '1',        '0.5',      '0.5');
+INSERT INTO Colors      (   Type,                                 Red,      Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_RESOURCE_LENS_BONUSNCONNECTED','0',      '1',        '0',        '0.5');
 
 -- Wonder Lens
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_NATURAL_WONDER_LENS',        '0',        '1',        '0',        '0.5');
+VALUES                  (   'COLOR_WONDER_LENS_NATURAL',        '0',        '1',        '0',        '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_PLAYER_WONDER_LENS',         '1',        '0',        '1',        '0.5');
+VALUES                  (   'COLOR_WONDER_LENS_PLAYER',         '1',        '0',        '1',        '0.5');
 
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_GHUT_SCOUT_LENS',            '1',        '0',        '1',        '0.5');
+VALUES                  (   'COLOR_SCOUT_LENS_GHUT',            '1',        '0',        '1',        '0.5');
 
 -- Naturalist Lens
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_PARK_NATURALIST_LENS',       '0',        '1',        '0',        '0.5');
+VALUES                  (   'COLOR_NATURALIST_LENS_PARK',       '0',        '1',        '0',        '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_OK_NATURALIST_LENS',         '0',        '1',        '1',        '0.5');
+VALUES                  (   'COLOR_NATURALIST_LENS_OK',         '0',        '1',        '1',        '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_FIXABLE_NATURALIST_LENS',    '0.56',     '0.0',      '0.98',     '0.5');
+VALUES                  (   'COLOR_NATURALIST_LENS_FIXABLE',    '0.56',     '0.0',      '0.98',     '0.5');
 
 
 -- City Manager Colors
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_CITY_PLOT_WORKING',          '1',        '0.5',      '0',        '0.2');
+VALUES                  (   'COLOR_CITY_PLOT_LENS_WORKING',     '1',        '0.5',      '0',        '0.2');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_CITY_PLOT_LOCKED',           '0',        '1',        '0',        '0.2');
+VALUES                  (   'COLOR_CITY_PLOT_LENS_LOCKED',      '0',        '1',        '0',        '0.2');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_CITY_PLOT_LENS_CULTURE',     '0.89',     '0.431',   '0.862',    '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_AREA_LENS_NEUTRAL',          '0',        '0',        '0',        '0.0');
 

--- a/Settings/ml_settingspanel.lua
+++ b/Settings/ml_settingspanel.lua
@@ -1,8 +1,9 @@
+include("InstanceManager");
 -- ===========================================================================
 --  Helper Functions
 -- ===========================================================================
 
--- Sourced from Azurency's CQUI link: https://github.com/Azurency/CQUI_Community-Edition/blob/master/Assets/UI/civ6common.lua
+-- Sourced from CivFanatics CQUI GitHub (originally via Azurency's GitHub): https://github.com/civfanatics/CQUI_Community-Edition/blob/main/Assets/cqui_settingselement.lua
 local function PopulateCheckBox(control, setting_name)
     local current_value = GameConfiguration.GetValue(setting_name);
     if (current_value == nil) then
@@ -29,6 +30,31 @@ local function PopulateCheckBox(control, setting_name)
     );
 end
 
+-- Object containing functions that convert either a value to a set slider notch, or convert a notch to a value
+local SliderControlConverter = {
+    ToSteps = function(value, min, max, numsteps)
+            -- Determine the position of the slider based on the number of steps in total
+            -- If the value is the same as the minimum, then the step value is 0.
+            local stepIncrement = math.floor((max - min + 1) / numsteps);
+            local out = math.floor((value - min) / stepIncrement);
+            if (out < 0) then
+                out = 0;
+            end
+
+            return out;
+        end,
+
+    ToValue = function(curstep, min, max, numsteps)
+            local stepIncrement = math.floor((max - min + 1) / numsteps);
+            local out = (curstep * stepIncrement) + min;
+
+            if (out > max) then
+                out = max;
+            end
+            return out;
+        end
+};
+
 function InitButton(control, callbackLClick, callbackRClick)
     control:RegisterCallback(Mouse.eLClick, callbackLClick)
     if callbackRClick ~= nil then
@@ -48,6 +74,8 @@ end
 
 local function OnClose()
     ContextPtr:SetHide(true);
+    LuaEvents.ML_SettingsUpdate();
+    LuaEvents.ML_SettingsPanelClosed();
 end
 
 -- ===========================================================================
@@ -75,6 +103,233 @@ local function OnShutdown()
     end
 end
 
+-- TEMP TEMP
+function DoClose()
+    local hudContainer = ContextPtr:LookUpControl("/InGame/HUD")
+    if hudContainer ~= nil then
+        hudContainer:DestroyChild(Controls.SettingsPanel)
+    end
+end
+
+-- ===========================================================================
+-- Configurable Colors for More Lenses controls (the_m4a, from CQUI)
+-- ===========================================================================
+
+-- This file contains the logic tied to the control instances created to allow updating
+-- of the lens colors in the More Lenses Settings panel
+local m_lensRGBSettingsIM = InstanceManager:new("LensRGBPickerLensGroupInstance", "LensRGBPickerLensGroupInstanceRoot", Controls.LensRGBPickerLensGroupStack);
+local m_sliderUpdating = false;
+local m_editBoxUpdating = false;
+
+-- ===========================================================================
+-- Create all of the control instances for each of the various colors available for each of the lenses
+-- Each "Lens" as found in the Modal Lens Panel is considered a Lens Category
+-- Each individual item in that Lens Category is a lens, where a slider control or an edit 
+-- box can be used to set the RGB values for that lens
+function PopulateLensRGBPickerSettings()
+    m_lensRGBSettingsIM:ResetInstances();
+
+    -- These are the modded lenses that have been updated so their colors can be set via the settings panel
+    -- The Lens names and locale text strings have been updated to follow a specific pattern,
+    -- Where a Lens "Base Name" has COLOR_LENSNAME_LENS, and all items for that lens are COLOR_LENSNAME_LENS_ITEM
+    -- For example, COLOR_ARCHAEOLOGIST_LENS_SHIPWRECK is for all of the ShipWreck tiles shown by the Archaeologist lens
+    local lensGroups = {
+        { LensGroupName = "LOC_HUD_ARCHAEOLOGIST_LENS", LensBaseName = "COLOR_ARCHAEOLOGIST_LENS"},
+        { LensGroupName = "LOC_HUD_BARBARIAN_LENS",     LensBaseName = "COLOR_BARBARIAN_LENS"},
+        { LensGroupName = "LOC_HUD_BUILDER_LENS",       LensBaseName = "COLOR_BUILDER_LENS" },
+        { LensGroupName = "LOC_HUD_CITYOVERLAP_LENS",   LensBaseName = "COLOR_CITYOVERLAP_LENS", RowLabelFunc = GenerateCityOverlapRowLabel},
+        { LensGroupName = "LOC_HUD_NATURALIST_LENS",    LensBaseName = "COLOR_NATURALIST_LENS"},
+        { LensGroupName = "LOC_HUD_RESOURCE_LENS",      LensBaseName = "COLOR_RESOURCE_LENS"},
+        { LensGroupName = "LOC_HUD_SCOUT_LENS",         LensBaseName = "COLOR_SCOUT_LENS"},
+        { LensGroupName = "LOC_HUD_WONDER_LENS",        LensBaseName = "COLOR_WONDER_LENS"}
+    };
+
+    for _,lensGroup in ipairs(lensGroups) do
+        -- catEntry is an entry for the category, containing 1-to-n rows of RGB Sliders
+        local lensGroupInstance = m_lensRGBSettingsIM:GetInstance();
+        lensGroupInstance.LensGroupLabel:SetText(Locale.Lookup(lensGroup.LensGroupName));
+        local lensRGBPickerRowIM = InstanceManager:new("LensRGBPickerRowInstance", "LensRGBPickerRowInstanceRoot", lensGroupInstance.LensRGBPickerRowInstanceStack);
+        -- MoreLenses adds its colors into the GameInfo.Colors table, so cycling through that list will get us the lens items in each lens category
+        for lensColorEntry in GameInfo.Colors() do
+            -- If LensBaseName is COLOR_FOO_LENS, then this matches COLOR_FOO_LENS_BAR, COLOR_FOO_LENS_STUFF, etc for the Type field of the item in GameInfo.Colors
+            if (string.find(lensColorEntry["Type"], lensGroup.LensBaseName)) then
+                local rowLabel = "";
+                if (lensGroup.RowLabelFunc ~= nil) then
+                    -- This lens group has a custom function for assigning the Row Label
+                    rowLabel = lensGroup.RowLabelFunc(lensColorEntry["Type"]);
+                else
+                    -- This turns COLOR_FOO_LENS_BAR into LOC_HUD_FOO_LENS_BAR
+                    rowLabel = Locale.Lookup(string.gsub(lensColorEntry["Type"], lensGroup.LensBaseName, lensGroup.LensGroupName));
+                end
+
+                -- Skip any entries that have a blank row label
+                if (string.len(rowLabel) > 0) then
+                    local lensRGBPickerRowInstance = lensRGBPickerRowIM:GetInstance();
+                    PopulateLensRGBPickerRowInstance(lensRGBPickerRowInstance, lensColorEntry["Type"], rowLabel);
+                end
+            end
+        end
+    end
+
+    -- Both of these controls are found in ml_settingspanel.xml
+    Controls.LensRGBPickerLensGroupStack:CalculateSize();
+    Controls.LensesOptionsScrollPanel:CalculateSize();
+end
+
+-- ===========================================================================
+-- Used to populate the Lens RGB Color Pickers asdf(each row item added to the settings control)
+-- pickerRowInstance: The instance returned by the lensColorSetting:GetInstance() call
+-- settingName: The name of the lens color item to be retrieved (e.g. COLOR_WONDER_LENS_NATURAL)
+-- rowLabel: The label for that row
+function PopulateLensRGBPickerRowInstance(pickerRowInstance, settingName, rowLabel)
+    local lensItemColorData = GameConfiguration.GetValue(settingName);
+    if (lensItemColorData == nil or lensItemColorData["Red"] == nil) then
+        -- if lensItemColor data is nil, then it has not yet been added to this GameConfiguration...
+        -- or if it has, but one of the fields (like Red) is nil, then the entire data structure may be corrupt.
+        -- So, get the default values from GameInfo.Colors that was placed by the MoreLenses_Colors.sql
+        if (GameInfo.Colors[settingName]) then
+            lensItemColorData = GameInfo.Colors[settingName];
+        else
+            -- Somehow this value does not exist.  Manually create it.  Note, there are missing fields, but we don't touch them, so...
+            lensItemColorData = { Type = settingName, Red = 0, Green = 0, Blue = 0, Alpha = 0.5 }
+        end
+
+        GameConfiguration.SetValue(settingName, lensItemColorData);
+    end
+
+    pickerRowInstance.RowLabel:SetText(rowLabel);
+
+    -- Add 3 instances of the Label/EditBox/Slider control, one each for Red, Green, and Blue
+    local lesIM = InstanceManager:new("LensRGBPickerLabelEditBoxSliderInstance", "LensRGBPickerLabelEditBoxSliderInstanceRoot", pickerRowInstance.LensRGBPickerLabelEditBoxSliderInstanceStack);
+    local lesArray = { Red = lesIM:GetInstance(), Green = lesIM:GetInstance(), Blue  = lesIM:GetInstance()};
+    for color, lesInstance in pairs(lesArray) do
+        lesInstance.LabelCtrl:SetText(Locale.Lookup("LOC_ML_LENSES_RGB_COLOR_SETTINGS_" .. string.upper(color)));
+
+        -- lensItemColorData[color] is a float (from the RGB Color setting) that requires conversion; this accomplishes rounding the value correctly, as well
+        local currentValue = math.floor((lensItemColorData[color] * 255) + 0.5);
+        lesInstance.SliderCtrl:SetStep(SliderControlConverter.ToSteps(currentValue, 0, 255, lesInstance.SliderCtrl:GetNumSteps()));
+        lesInstance.EditBoxCtrl:SetText(currentValue);
+
+        -- Callback function called whenever the slider changes
+        lesInstance.SliderCtrl:RegisterSliderCallback(LensRGBPickerSliderCallback(lesInstance, pickerRowInstance.ColorPreviewBox, settingName, color));
+        -- Callback function called whenever the edit box is updated
+        lesInstance.EditBoxCtrl:RegisterStringChangedCallback(LensRGBPickerEditBoxCallback(lesInstance, pickerRowInstance.ColorPreviewBox, settingName, color));
+
+        if (tooltip ~= nil and string.len(tooltip) > 0) then
+            editBoxControl:SetToolTipString(tooltip);
+        end
+
+        lesInstance.LabelStack:CalculateSize();
+    end
+
+    pickerRowInstance.LensRGBPickerLabelEditBoxSliderInstanceStack:CalculateSize();
+ 
+    -- Give the color preview box its initial coloring
+    pickerRowInstance.ColorPreviewBox:SetColor(UI.GetColorValue(lensItemColorData["Red"], lensItemColorData["Green"], lensItemColorData["Blue"]));
+
+    -- Configure the click action for the Default button, which will reset the color preview box as well as the slider control and edit boxes
+    pickerRowInstance.RestoreDefaultButton:RegisterCallback(Mouse.eLClick, LensRGBPickerRestoreDefaultButtonCallback(pickerRowInstance, lesArray, settingName));
+end
+
+-- ===============================================================================================
+-- Callback function for when the Restore Default button is clicked
+function LensRGBPickerRestoreDefaultButtonCallback(pickerRowInstance, lesArray, settingName)
+    return function()
+        -- Get the default value from the GameInfo.Colors DB (as set by morelenses_colors.sql),
+        -- then set the setting by the same name in GameConfiguration to that value.
+        lensColorData = GameInfo.Colors[settingName];
+        GameConfiguration.SetValue(settingName, lensColorData);
+        -- Update all of the controls
+        pickerRowInstance.ColorPreviewBox:SetColor(UI.GetColorValue(lensColorData["Red"], lensColorData["Green"], lensColorData["Blue"]));
+        for color, lesInstance in pairs(lesArray) do
+            -- This is effectively how to round a value in lua
+            local current_value = math.floor((lensColorData[color] * 255) + 0.5);
+            lesInstance.SliderCtrl:SetStep(SliderControlConverter.ToSteps(current_value, 0, 255, lesInstance.SliderCtrl:GetNumSteps()));
+            lesInstance.EditBoxCtrl:SetText(current_value);
+        end
+    end
+end
+
+-- ===========================================================================
+-- Callback function for when a Slider control is being manipulated
+function LensRGBPickerSliderCallback(lesInstance, previewBoxCtrl, settingName, controlColor)
+    return function()
+        m_sliderUpdating = true;
+
+        -- Get value, update the color changed, set value
+        local value = SliderControlConverter.ToValue(lesInstance.SliderCtrl:GetStep(), 0, 255, lesInstance.SliderCtrl:GetNumSteps());
+        local lensData = GameConfiguration.GetValue(settingName);
+        lensData[controlColor] = value / 255.0;
+        GameConfiguration.SetValue(settingName, lensData);
+
+        if (false == m_editBoxUpdating) then
+            -- if m_editBoxUpdating is true, then this callback was called as a result of the editbox callback updating the slider control
+            -- therefore it is not necessary to set the preview box or editbox control values, as they will already be updated in that callback
+            lesInstance.EditBoxCtrl:SetText(value);
+            previewBoxCtrl:SetColor(UI.GetColorValue(lensData["Red"], lensData["Green"], lensData["Blue"]));
+        end
+
+        -- Note: Calling the ML_SettingsUpdate LuaEvent here is very slow and not necessary as this Callback is called with every movement
+        --       of the slider tab.  Instead, the ML_SettingsUpdate LuaEvent is called when the ML Settings panel is closed. 
+        m_sliderUpdating = false;
+    end
+end
+
+-- ===========================================================================
+-- Callback function for when a text box is being edited
+function LensRGBPickerEditBoxCallback(lesInstance, previewBoxCtrl, settingName, controlColor)
+    return function()
+        m_editBoxUpdating = true;
+
+        local numVal:number = 0;
+        local userInput:string = lesInstance.EditBoxCtrl:GetText();
+        if (string.len(userInput) > 0 and tonumber(userInput) == nil) then
+            -- Box isn't blank, but also not a number
+            lesInstance.EditBoxCtrl:SetText("0");
+        else
+            numVal = tonumber(userInput);
+            if (numVal < 0) then
+                lesInstance.EditBoxCtrl:SetText("0");
+                numVal = 0;
+            elseif (numVal > 255) then
+                lesInstance.EditBoxCtrl:SetText("255");
+                numVal = 255;
+            end
+        end
+
+        local lensData = GameConfiguration.GetValue(settingName);
+        lensData[controlColor] = numVal / 255.0;
+        GameConfiguration.SetValue(settingName, lensData);
+
+        if (false == m_sliderUpdating) then
+            -- if m_sliderUpdating is true, then this callback was called as a result of the slider callback updating the edit box value
+            -- therefore it is not necessary to set the preview box or slider control values, as they will already be updated in that callback
+            previewBoxCtrl:SetColor(UI.GetColorValue(lensData["Red"], lensData["Green"], lensData["Blue"]));
+            lesInstance.SliderCtrl:SetStep(SliderControlConverter.ToSteps(numVal, 0, 255, lesInstance.SliderCtrl:GetNumSteps()));
+        end
+
+        -- Note: Calling the ML_SettingsUpdate LuaEvent here is not necessary.
+        --       Instead, the ML_SettingsUpdate LuaEvent is called when the ML Settings panel is closed. 
+        m_editBoxUpdating = false;
+    end
+end
+
+-- ===========================================================================
+-- Generate the Row Label for the City Overlap entry
+function GenerateCityOverlapRowLabel(lensTypeName)
+    -- CityOverlap has a special case handling for the KeyLabel
+    --     ["COLOR_CITYOVERLAP_LENS_1"] =  { ConfiguredColor = GetLensColorFromSettings("COLOR_CITYOVERLAP_LENS_1"), KeyLabel = "LOC_WORLDBUILDER_TAB_CITIES".." +1" },
+    -- So, if lensTypeName is COLOR_CITYOVERLAP_LENS_1, the row Label should be "Cities +1", which uses the LOC_WORLDBUILDER_TAB_CITIES string
+    -- This gets the last two characters in the string, so it would get 1 from COLOR_CITYOVERLAP_LENS_1
+    local cityOverlapLensRow = string.sub(lensTypeName, -1);
+    local rowLabel = Locale.Lookup("LOC_WORLDBUILDER_TAB_CITIES").." +"..cityOverlapLensRow;
+    return rowLabel;
+end
+
+-- ===========================================================================
+--  End Section imported from CQUI Settings
+-- ===========================================================================
+
 -- ===========================================================================
 --  Init
 -- ===========================================================================
@@ -93,6 +348,9 @@ local function Initialize()
     PopulateCheckBox(Controls.BuilderLensDisableDangerous, "ML_BuilderLensDisableDangerousHighlight")
     PopulateCheckBox(Controls.AutoApplyScoutLensCheckbox, "ML_AutoApplyScoutLens")
     PopulateCheckBox(Controls.AutoApplyScoutLensExtraCheckbox, "ML_AutoApplyScoutLensExtra")
+
+    -- Add color settings for lenses added by ML
+    PopulateLensRGBPickerSettings();
 
     -- Call this once to ensure all files have updated settings
     LuaEvents.ML_SettingsUpdate();

--- a/Settings/ml_settingspanel.xml
+++ b/Settings/ml_settingspanel.xml
@@ -1,26 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Context>
-  <Container ID="SettingsPanel" Size="380,512" Anchor="C,C" ConsumeMouse="1">
-    <Grid Size="parent,parent" Texture="Controls_ContainerBlue" SliceStart="0,0" SliceCorner="3,3" SliceSize="9,9" SliceTextureSize="16,16">
-      <Container ID="Header" Size="parent,54" Anchor="C,T" Style="ShellHeaderContainer">
-        <Grid Style="ShellHeaderButtonGrid">
-          <Label Style="FontFlair24" FontStyle="glow" ColorSet="ShellHeader" Anchor="C,C" String="LOC_HUD_ML_SETTINGS_PANEL_TITLE"/>
-        </Grid>
-      </Container>
+  <Container ID="SettingsPanel" Size="800,512" Anchor="C,C" ConsumeMouse="1">
+    <Grid Size="parent,auto" Texture="Controls_ContainerBlue" SliceStart="0,0" SliceCorner="3,3" SliceSize="9,9" SliceTextureSize="16,16">
+      <Stack Anchor="C,T" Size="parent,auto" StackGrowth="Down" Padding="5" Offset="0,0">
+        <Container ID="Header" Size="parent,54" Anchor="C,T" Style="ShellHeaderContainer">
+          <Grid Style="ShellHeaderButtonGrid">
+            <Label Style="FontFlair24" FontStyle="glow" ColorSet="ShellHeader" Anchor="C,C" String="LOC_HUD_ML_SETTINGS_PANEL_TITLE"/>
+          </Grid>
+        </Container>
 
-      <Container ID="GeneralOptions" Size="parent,parent-54" Offset="0,20" Hidden="0" Anchor="C,T">
-        <Stack Anchor="C,T" StackGrowth="Down" Padding="5" Offset="0,50">
-          <GridButton ID="AutoApplyBuilderLensCheckbox" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_AUTO_APPLY_BUILDER" ToolTip="LOC_TOOLTOP_ML_SETTINGS_AUTO_APPLY_BUILDER"/>
-          <GridButton ID="BuilderLensDisableNothing" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_BUILDER_DISABLE_NOTHING" ToolTip="LOC_TOOLTOP_ML_SETTINGS_BUILDER_DISABLE_NOTHING"/>
-          <GridButton ID="BuilderLensDisableDangerous" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_BUILDER_DISABLE_DANGEROUS" ToolTip="LOC_TOOLTOP_ML_SETTINGS_BUILDER_DISABLE_DANGEROUS"/>
-          <GridButton ID="AutoApplyScoutLensCheckbox" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_AUTO_APPLY_SCOUT" ToolTip="LOC_TOOLTOP_ML_SETTINGS_AUTO_APPLY_SCOUT"/>
-          <GridButton ID="AutoApplyScoutLensExtraCheckbox" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_AUTO_APPLY_SCOUT_EXTRA" ToolTip="LOC_TOOLTOP_ML_SETTINGS_AUTO_APPLY_SCOUT_EXTRA"/>
-        </Stack>
-      </Container>
+        <Container ID="GeneralOptions" Size="parent,parent-54" Hidden="0" Anchor="C,T">
+          <ScrollPanel ID="LensesOptionsScrollPanel" Anchor="C,T" Size="parent-20,parent-5" AutoScrollBar="1" Vertical="1">
+            <Stack Anchor="C,T" Size="parent,auto" StackGrowth="Down" Padding="5" Offset="0,0">
+              <Stack Anchor="C,T" StackGrowth="Down" Padding="5">
+                <GridButton ID="AutoApplyBuilderLensCheckbox" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_AUTO_APPLY_BUILDER" ToolTip="LOC_TOOLTOP_ML_SETTINGS_AUTO_APPLY_BUILDER"/>
+                <GridButton ID="BuilderLensDisableNothing" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_BUILDER_DISABLE_NOTHING" ToolTip="LOC_TOOLTOP_ML_SETTINGS_BUILDER_DISABLE_NOTHING"/>
+                <GridButton ID="BuilderLensDisableDangerous" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_BUILDER_DISABLE_DANGEROUS" ToolTip="LOC_TOOLTOP_ML_SETTINGS_BUILDER_DISABLE_DANGEROUS"/>
+                <GridButton ID="AutoApplyScoutLensCheckbox" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_AUTO_APPLY_SCOUT" ToolTip="LOC_TOOLTOP_ML_SETTINGS_AUTO_APPLY_SCOUT"/>
+                <GridButton ID="AutoApplyScoutLensExtraCheckbox" Anchor="L,C" Offset="0,0" Size="340,24" Style="CheckBoxControl" String="LOC_HUD_ML_SETTINGS_AUTO_APPLY_SCOUT_EXTRA" ToolTip="LOC_TOOLTOP_ML_SETTINGS_AUTO_APPLY_SCOUT_EXTRA"/>
+              </Stack>
+              <!-- </Container> -->
+              <!-- Lenses Color Settings -->
+              <!-- <Stack Anchor="C,C" StackGrowth="Left"> -->
+              <Label Anchor="C,C" Style="ShellOptionText" Offset="0,0" String="LOC_ML_LENSES_RGB_COLOR_SETTINGS"/>
+              <!-- </Stack> -->
+              <Line Anchor="C,C" Start="0,0" End="500,0" Width="2" Color="84,77,66,255"/>
+              <!-- Categories each with 1 or more controls contained within -->
+              <Stack ID="LensRGBPickerLensGroupStack" Anchor="L,T" StackGrowth="Down" Size="parent,0" Padding="5">
+              </Stack>
+            </Stack>
+            <ScrollBar Style="Slider_Blue" Anchor="R,C" AnchorSide="O,I"/>
+          </ScrollPanel>
+        </Container>
 
-      <Container ID="Header" Size="parent,60" Anchor="C,B" Offset="0,-5" Style="ShellHeaderContainer">
-        <GridButton ID="ConfirmButton" Style="ButtonConfirm" Anchor="C,C" Offset="0,-1" String="LOC_AUTONARRATE_BUTTON_DONE" Size="300,41"/>
-      </Container>
+        <Container ID="Header" Size="parent,60" Anchor="C,B" Offset="0,-5" Style="ShellHeaderContainer">
+          <GridButton ID="ConfirmButton" Style="ButtonConfirm" Anchor="C,C" Offset="0,-1" String="LOC_AUTONARRATE_BUTTON_DONE" Size="300,41"/>
+        </Container>
+      </Stack>
     </Grid>
   </Container>
+  <!-- More Lenses Color Editing Controls -->
+  <!-- Each Category instance contains a label and rows for each lens -->
+  <!-- Each row (LensRGBPickerRowInstance) contains three elements (LensRGBPickerLabelEditBoxSliderInstance) to control the red, green, and blue values -->
+  <!-- Each LensRGBPickerLabelEditBoxSliderInstance has a slider control (0 to 255) and an edit box to allow typing of values -->
+  <Instance Name="LensRGBPickerLensGroupInstance">
+    <Stack ID="LensRGBPickerLensGroupInstanceRoot" Anchor="L,C" StackGrowth="Down" Padding="5" Size="parent-10,30">
+      <Label ID="LensGroupLabel" Anchor="C,T" Style="ShellOptionText" String=""/>
+      <Stack ID="LensRGBPickerRowInstanceStack" Anchor="L,C" StackGrowth="Down" Padding="2" Size="auto,30"></Stack>
+    </Stack>
+  </Instance>
+
+  <Instance Name="LensRGBPickerRowInstance">
+    <Stack ID="LensRGBPickerRowInstanceRoot" Anchor="C,C" StackGrowth="Left" Padding="5" Size="parent-10,30">
+      <GridButton ID="RestoreDefaultButton" Anchor="R,C" Style="ButtonControl" Size="50,22" FontSize="10" String="LOC_DEFAULT_BUTTON"/>
+      <Box ID="ColorPreviewBox" Anchor="R,C" Size="22,22" Color="0,0,0,128"/>
+      <Stack ID="LensRGBPickerLabelEditBoxSliderInstanceStack" Anchor="C,C" StackGrowth="Right" Padding="2" Size="auto,30"></Stack>
+      <Label ID="RowLabel" Anchor="L,C" Align="left" Style="FontNormal12" WrapWidth="192" ColorSet="ShellOptionText" String=""/>
+    </Stack>
+  </Instance>
+
+  <Instance Name="LensRGBPickerLabelEditBoxSliderInstance">
+    <Stack ID="LensRGBPickerLabelEditBoxSliderInstanceRoot" Anchor="C,C" StackGrowth="Right" Padding="5">
+      <Stack ID="LabelStack" Anchor="L,C" StackGrowth="Right" Padding="5">
+        <Label ID="LabelCtrl" Anchor="L,C" Style="WhiteSemiBold12" String=""/>
+        <Grid Anchor="R,C" Texture="EditTextArea" InnerPadding="6,6" Size="28,18">
+          <ColorBox Color="0,0,0,90" Anchor="C,C" Size="auto,auto" SizePadding="1,1">
+            <EditBox ID="EditBoxCtrl" Anchor="C,C" EditMode="1" MinSize="22,12" Style="WhiteSemiBold12" String="0" MaxLength="3"/>
+          </ColorBox>
+        </Grid>
+      </Stack>
+      <Slider ID="SliderCtrl" Anchor="L,C" Style="SliderControl" Size="100,13" Offset="0,0" SpaceForScroll="0" Steps="255"/>
+    </Stack>
+  </Instance>
 </Context>

--- a/Text/MoreLenses_Text.xml
+++ b/Text/MoreLenses_Text.xml
@@ -50,10 +50,10 @@
     <Row Tag="LOC_HUD_ARCHAEOLOGIST_LENS_TOOLTIP">
       <Text>Highlights archaeologist dig sites.</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_ARCHAEOLOGIST_LENS_ARTIFACT">
+    <Row Tag="LOC_HUD_ARCHAEOLOGIST_LENS_ARTIFACT">
       <Text>Artifact</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_ARCHAEOLOGIST_LENS_SHIPWRECK">
+    <Row Tag="LOC_HUD_ARCHAEOLOGIST_LENS_SHIPWRECK">
       <Text>Shipwreck</Text>
     </Row>
 
@@ -68,7 +68,7 @@
       <Text>Highlight outside border</Text>
     </Row>
     <Row Tag="LOC_PANEL_CITYOVERLAP_NMOUSE">
-        <Text>No Mouse</Text>
+      <Text>No Mouse</Text>
     </Row>
     <Row Tag="LOC_PANEL_CITYOVERLAP_RANGE">
       <Text>Range</Text>
@@ -87,7 +87,7 @@
     <Row Tag="LOC_HUD_BARBARIAN_LENS_TOOLTIP">
       <Text>Highlights barbarian encampments on the map</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_BARBARIAN_LENS_ENCAPMENT">
+    <Row Tag="LOC_HUD_BARBARIAN_LENS_ENCAMPMENT">
       <Text>Barbarian Encampment</Text>
     </Row>
 
@@ -101,22 +101,22 @@
     <Row Tag="LOC_HUD_RESOURCE_LENS_COUNT_TOOLTIP">
       <Text>You own {1_Count} ({2_Count} improved) of the total {3_Count} discovered plots of {4_Resource}.</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_BONUS">
+    <Row Tag="LOC_HUD_RESOURCE_LENS_BONUSCONNECTED">
       <Text>Bonus Resource</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_NBONUS">
+    <Row Tag="LOC_HUD_RESOURCE_LENS_BONUSNCONNECTED">
       <Text>Unconnected Bonus Resource</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_LUXURY">
+    <Row Tag="LOC_HUD_RESOURCE_LENS_LUXCONNECTED">
       <Text>Luxury Resource</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_NLUXURY">
+    <Row Tag="LOC_HUD_RESOURCE_LENS_LUXNCONNECTED">
       <Text>Unconnected Luxury Resource</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_STRATEGIC">
+    <Row Tag="LOC_HUD_RESOURCE_LENS_STRATCONNECTED">
       <Text>Strategic Resource</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_NSTRATEGIC">
+    <Row Tag="LOC_HUD_RESOURCE_LENS_STRATNCONNECTED">
       <Text>Unconnected Strategic Resource</Text>
     </Row>
 
@@ -127,10 +127,10 @@
     <Row Tag="LOC_HUD_WONDER_LENS_TOOLTIP">
       <Text>Highlights natural wonders and built wonders built by players</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_WONDER_LENS_NWONDER">
+    <Row Tag="LOC_HUD_WONDER_LENS_NATURAL">
       <Text>Natural Wonder</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_RESOURCE_LENS_PWONDER">
+    <Row Tag="LOC_HUD_WONDER_LENS_PLAYER">
       <Text>Player-made Wonder</Text>
     </Row>
 
@@ -149,7 +149,7 @@
     <Row Tag="LOC_HUD_SCOUT_LENS_TOOLTIP">
       <Text>Highlights goody huts on the map</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_SCOUT_LENS_GHUT">
+    <Row Tag="LOC_HUD_SCOUT_LENS_GHUT">
       <Text>Goody Hut</Text>
     </Row>
 
@@ -160,13 +160,13 @@
     <Row Tag="LOC_HUD_NATURALIST_LENS_TOOLTIP">
       <Text>Highlights places where National Parks can be built</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_NPARK">
+    <Row Tag="LOC_HUD_NATURALIST_LENS_PARK">
       <Text>Area is ready for National Park</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_OK">
+    <Row Tag="LOC_HUD_NATURALIST_LENS_OK">
       <Text>Tile could be used, if some other plot is fixed</Text>
     </Row>
-    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_FIXABLE">
+    <Row Tag="LOC_HUD_NATURALIST_LENS_FIXABLE">
       <Text>Needs fixing to be used for a park</Text>
     </Row>
 
@@ -210,5 +210,17 @@
       <Text>Enable this to automatically apply the Scout lens when selecting all military units.</Text>
     </Row>
 
+    <Row Tag="LOC_ML_LENSES_RGB_COLOR_SETTINGS">
+      <Text>RGB Color Settings for Custom Lenses</Text>
+    </Row>
+    <Row Tag="LOC_ML_LENSES_RGB_COLOR_SETTINGS_RED">
+      <Text>Red</Text>
+    </Row>
+    <Row Tag="LOC_ML_LENSES_RGB_COLOR_SETTINGS_GREEN">
+      <Text>Green</Text>
+    </Row>
+    <Row Tag="LOC_ML_LENSES_RGB_COLOR_SETTINGS_BLUE">
+      <Text>Blue</Text>
+    </Row>
   </BaseGameText>
 </GameData>


### PR DESCRIPTION
I mentioned in #45 - I had enough requests and personal interest in this kind of thing with CQUI that I wanted to give it a shot.  And because it built off of your work with ML, I wanted to also share the changes if you were interested in incorporating that functionality into ML.  Pictures/gifs below.

**Notes on the Code Changes:**
- By and large this is the same logic that I put into CQUI to do this; anything "CQUI" was renamed to "ML", and I removed references to the custom CQUI Citizen Management lens.
- The updates to the non-English Text XML are not yet part of this PR.  I will add them next time I get the chance to do the work on this, sometime over the next few days.
- In order to allow the settings code to make some assumptions, I did some renaming of objects so their "COLOR" and "LOC_HUD" names aligned 
  - for example: "COLOR_FOO_LENS_BAR" will now always have a "LOC_HUD_FOO_LENS_BAR" counterpart.
- In spite of many files changed, I tried to keep changes as reasonable as I could.
- Using the "ignore whitespace" option for at least the ML_Settings.xml, as I had to add some controls and it messes with indenting and whatnot.

**Notes on Functionality:**
- The values apply on a per-saved game basis, like most settings of this nature.
- The "default" button reverts a lens color back to the value found in the Color Settings table
- The updated colors apply when the panel is closed, updating colors immediately (like when moving the scroll bar for a color) was really slow (at least with CQUI, anyway)
- Once updated the Key will also update (if opened via the Lenses panel)

**Pics / Gifs:**
![image](https://user-images.githubusercontent.com/8787640/119781528-f9712d00-be7f-11eb-99be-0c2c49a2ed38.png)
![gif](https://i.imgur.com/SLXxQ2C.gif)
![gif](https://i.imgur.com/hSVHmrK.gif)

