### PR TITLE
fix: Fix Korean translation

### DIFF
--- a/Text/MoreLenses_Text_ko.xml
+++ b/Text/MoreLenses_Text_ko.xml
@@ -117,7 +117,7 @@
 
     <!-- Scout Lens -->
     <Replace Tag="LOC_HUD_SCOUT_LENS" Language="ko_KR">
-      <Text>정잘병</Text>
+      <Text>정찰병</Text>
     </Replace>
     <Replace Tag="LOC_HUD_SCOUT_LENS_TOOLTIP" Language="ko_KR">
       <Text>부족 마을을 나타냅니다.</Text>


### PR DESCRIPTION
Fixes a type in Korean translation where the word "scout" (currently is "정잘병") should be "정찰병"